### PR TITLE
Fix: Empty buffer coercion failure on Linux

### DIFF
--- a/src/spectrum/bindata/encodings.rs
+++ b/src/spectrum/bindata/encodings.rs
@@ -201,6 +201,17 @@ pub enum ArrayRetrievalError {
     DataTypeSizeMismatch,
 }
 
+impl From<bytemuck::PodCastError> for ArrayRetrievalError {
+    fn from(value: bytemuck::PodCastError) -> Self {
+        match value {
+            bytemuck::PodCastError::TargetAlignmentGreaterAndInputNotAligned => Self::DataTypeSizeMismatch,
+            bytemuck::PodCastError::OutputSliceWouldHaveSlop => Self::DataTypeSizeMismatch,
+            bytemuck::PodCastError::SizeMismatch => Self::DataTypeSizeMismatch,
+            bytemuck::PodCastError::AlignmentMismatch => Self::DataTypeSizeMismatch,
+        }
+    }
+}
+
 impl From<ArrayRetrievalError> for io::Error {
     fn from(value: ArrayRetrievalError) -> Self {
         match value {

--- a/src/spectrum/bindata/traits.rs
+++ b/src/spectrum/bindata/traits.rs
@@ -14,9 +14,9 @@ pub trait ByteArrayView<'transient, 'lifespan: 'transient> {
         buffer: Cow<'transient, [u8]>,
     ) -> Result<Cow<'transient, [T]>, ArrayRetrievalError> {
         let n = buffer.len();
-        // if n == 0 {
-        //     return Ok(Cow::Owned(Vec::new()))
-        // }
+        if n == 0 {
+            return Ok(Cow::Owned(Vec::new()))
+        }
         let z = mem::size_of::<T>();
         if n % z != 0 {
             return Err(ArrayRetrievalError::DataTypeSizeMismatch);


### PR DESCRIPTION
[Rust 1.78](https://blog.rust-lang.org/2024/05/02/Rust-1.78.0.html#asserting-unsafe-preconditions) now crashes on `slice::from_raw_parts` when coercing an empty slice across types, when it did not previously. 