### PR TITLE
Fixed a crash in mgf scan number search

### DIFF
--- a/src/io/mgf.rs
+++ b/src/io/mgf.rs
@@ -594,9 +594,8 @@ impl<R: SeekRead, C: CentroidPeakAdapting, D: DeconvolutedPeakAdapting>
 {
     /// Retrieve a spectrum by it's native ID
     fn get_spectrum_by_id(&mut self, id: &str) -> Option<MultiLayerSpectrum<C, D>> {
-        let offset_ref = self.index.get(id);
-        let offset = offset_ref.expect("Failed to retrieve offset");
-        let index = self.index.index_of(id).unwrap();
+        let offset = self.index.get(id)?;
+        let index = self.index.index_of(id)?;
         let start = self
             .handle
             .stream_position()
@@ -606,13 +605,10 @@ impl<R: SeekRead, C: CentroidPeakAdapting, D: DeconvolutedPeakAdapting>
         let result = self.read_next();
         self.seek(SeekFrom::Start(start))
             .expect("Failed to restore offset");
-        match result {
-            Some(mut scan) => {
+        result.map(|mut scan| {
                 scan.description.index = index;
-                Some(scan)
-            }
-            None => None,
-        }
+            scan
+        })
     }
 
     /// Retrieve a spectrum by it's integer index


### PR DESCRIPTION
When searching for a scan number in an mgf file the search crashed [at this location](https://github.com/mobiusklein/mzdata/blob/main/src/io/mgf.rs#L598C18-L598C69). I saw that it always panics when the index is not found while the function is allowed to return `None`. So I made it return `None` when the name could not be found. Additionally, I changed the later match statement into a map.