### PR TITLE
fix: publicly re-export `mzpeaks` dependency to guarantee `mz_read` works.

### DIFF
--- a/src/io/shorthand.rs
+++ b/src/io/shorthand.rs
@@ -28,7 +28,7 @@ use super::{Sink, Source, SpectrumSource};
 #[macro_export]
 macro_rules! mz_read {
     ($source:expr, $reader:ident => $impl:tt) => {
-        $crate::mz_read!($source, $reader => $impl, mzpeaks::CentroidPeak, mzpeaks::DeconvolutedPeak)
+        $crate::mz_read!($source, $reader => $impl, $crate::mzpeaks::CentroidPeak, $crate::mzpeaks::DeconvolutedPeak)
     };
     ($source:expr, $reader:ident => $impl:tt, $C:ty, $D:ty) => {{
         let source = $crate::io::Source::<_, _>::from($source);
@@ -208,7 +208,7 @@ macro_rules! mz_read {
 #[macro_export]
 macro_rules! mz_write {
     ($sink:expr, $writer:ident => $impl:tt) => {
-        mz_write!($sink, $writer => $impl, mzpeaks::CentroidPeak, mzpeaks::DeconvolutedPeak)
+        mz_write!($sink, $writer => $impl, $crate::mzpeaks::CentroidPeak, $crate::mzpeaks::DeconvolutedPeak)
     };
     ($sink:expr, $writer:ident => $impl:tt, $C:ty, $D:ty) => {{
         let sink = $crate::io::Sink::<$C, $D>::from($sink);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,3 +81,5 @@ pub use crate::spectrum::{CentroidSpectrum, RawSpectrum, Spectrum};
 
 #[cfg(doc)]
 pub mod tutorial;
+
+pub use mzpeaks;


### PR DESCRIPTION
When using the `mz_read` macro, at the moment you need to declare a dependency on mzpeaks for it to work. This can also result in issues due to version mismatches between the mzpeaks version used to build mzdata, and the version declared in your own project. `pub use` prevents this by making sure that the version used in the `mz_read` is the one used in mzdata, and avoids the need to make mzpeaks an additional dependency at all.