### PR TITLE
Fixed rare crash while mgf parsing

### DIFF
--- a/src/io/mgf.rs
+++ b/src/io/mgf.rs
@@ -8,7 +8,6 @@ use std::convert::TryInto;
 use std::fs;
 use std::io::{self, prelude::*, BufWriter, SeekFrom};
 use std::marker::PhantomData;
-use std::mem;
 use std::str;
 
 use log::warn;
@@ -508,10 +507,7 @@ impl<R: io::Read, C: CentroidPeakAdapting, D: DeconvolutedPeakAdapting> MGFReade
                 MGFParserState::Between => self.handle_between(line),
                 MGFParserState::Done => false,
                 MGFParserState::Error => {
-                    let mut err = None;
-                    mem::swap(&mut self.error, &mut err);
-                    self.error = None;
-                    return Err(err.unwrap());
+                    return Err(self.error.take().unwrap_or(MGFError::NoError));
                 }
             };
         }


### PR DESCRIPTION
I found a rare crash while reading MGF files. By the way the function [`Option::take`](https://doc.rust-lang.org/std/option/enum.Option.html#method.take) does exactly what you are doing with `mem::swap` while being more main stream in other Rust code. I saw this same pattern at some other places in the code base so changing those might be warranted.

I am currently debugging why MGF reading is broken in my annotator so there might be more fixes coming.