### PR TITLE
Fixed parsing bug for USI continaining a colon in the interpretation

### DIFF
--- a/src/io/usi.rs
+++ b/src/io/usi.rs
@@ -44,7 +44,7 @@ pub struct USI {
     pub run_name: String,
     pub identifier: Option<Identifier>,
     pub interpretation: Option<String>,
-    pub provenance: Option<String>,
+    pub provenance: Option<(Repository, String)>,
 }
 
 impl FromStr for USI {
@@ -123,10 +123,14 @@ impl FromStr for USI {
                         };
 
                         let tail = tokens.next().map_or((None, None), |tail| {
-                            const REPOSITORY_CODES: &[&str] = &["PR", "PA", "MA", "JP", "IP", "PP"];
-                            for code in REPOSITORY_CODES {
-                                if let Some((i, p)) = tail.rsplit_once(&format!(":{code}-")) {
-                                    return (Some(i.to_string()), Some(p.to_string()));
+                            for repository in Repository::ALL {
+                                if let Some((i, p)) =
+                                    tail.rsplit_once(&format!(":{}-", repository.code()))
+                                {
+                                    return (
+                                        Some(i.to_string()),
+                                        Some((*repository, p.to_string())),
+                                    );
                                 }
                             }
                             (Some(tail.to_string()), None)
@@ -173,13 +177,56 @@ impl Display for USI {
             if let Some(interp) = self.interpretation.as_ref() {
                 write!(f, ":{}", interp)?;
                 if let Some(provenance) = self.provenance.as_ref() {
-                    write!(f, ":{}", provenance)?;
+                    write!(f, ":{}-{}", provenance.0, provenance.1)?;
                 }
             }
             Ok(())
         } else {
             write!(f, "{}:{}:{}", self.protocol, self.dataset, self.run_name)
         }
+    }
+}
+
+/// A repository that can be used for provenance IDs.
+#[allow(non_camel_case_types)]
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Ord, Eq, Hash, Default)]
+pub enum Repository {
+    #[default]
+    Pride,
+    PeptideAtlas,
+    MassIVE,
+    jPOST,
+    iProx,
+    PanoramaPublic,
+}
+
+impl Repository {
+    /// All repositories listed for programmatic access
+    const ALL: &[Self] = &[
+        Self::Pride,
+        Self::PeptideAtlas,
+        Self::MassIVE,
+        Self::jPOST,
+        Self::iProx,
+        Self::PanoramaPublic,
+    ];
+
+    /// Get the repository code as used in a USI provenance ID
+    pub const fn code(&self) -> &'static str {
+        match self {
+            Self::Pride => "PR",
+            Self::PeptideAtlas => "PA",
+            Self::MassIVE => "MA",
+            Self::jPOST => "JP",
+            Self::iProx => "IP",
+            Self::PanoramaPublic => "PP",
+        }
+    }
+}
+
+impl std::fmt::Display for Repository {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.code())
     }
 }
 
@@ -285,6 +332,20 @@ mod test {
             Some("<[Cation:K]@N-term:E>GGKIE[Cation:K|Info:(((((([]}}}}}}}}<<<<<<{{{)(>>[((((){>>>><>>))}}{}]}]VQLK/4".to_string())
         );
         assert_eq!(usi.provenance, None);
+        Ok(())
+    }
+
+    #[test]
+    fn test_provenance() -> Result<(), USIParseError> {
+        let usi: USI = "mzspec:PXD000561:Adult_Frontalcortex_bRP_Elite_85_f09:scan:17555:VLH[UNIMOD:1]PLEGAVVIIFK/2:PR-G47".parse()?;
+        assert_eq!(usi.dataset, "PXD000561");
+        assert_eq!(usi.run_name, "Adult_Frontalcortex_bRP_Elite_85_f09");
+        assert_eq!(usi.identifier, Some(Identifier::Scan(17555)));
+        assert_eq!(
+            usi.interpretation,
+            Some("VLH[UNIMOD:1]PLEGAVVIIFK/2".to_string())
+        );
+        assert_eq!(usi.provenance, Some((Repository::Pride, "G47".to_string())));
         Ok(())
     }
 }

--- a/src/io/usi.rs
+++ b/src/io/usi.rs
@@ -125,7 +125,7 @@ impl FromStr for USI {
                         let tail = tokens.next().map_or((None, None), |tail| {
                             const REPOSITORY_CODES: &[&str] = &["PR", "PA", "MA", "JP", "IP", "PP"];
                             for code in REPOSITORY_CODES {
-                                if let Some((i, p)) = tail.split_once(&format!(":{code}-")) {
+                                if let Some((i, p)) = tail.rsplit_once(&format!(":{code}-")) {
                                     return (Some(i.to_string()), Some(p.to_string()));
                                 }
                             }


### PR DESCRIPTION
I changed the parsing to recognise the provinance identifiers to split the last remaining piece (interpretation+provinance) based on that. I first explored a stack based approach but that quickly grew in complexity. Additionally the specification is very unclear about provinances, but I think you know that as well, so I did not want to assume anything about the validity of using any kind of brackets in the provinance. If the specification was updated to disallow any kind of bracket (all of "()[]{}<>") the code could be changed to look for the last colon, but if it finds any bracket before it finds a colon it returns the full tail as the interpretation.