### PR TITLE
Add isq7k, support multiple FAIMS voltages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,13 +681,23 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.20"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -775,9 +785,9 @@ dependencies = [
 
 [[package]]
 name = "dlopen2"
-version = "0.6.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bc2c7ed06fd72a8513ded8d0d2f6fd2655a85d6885c48cae8625d80faf28c03"
+checksum = "b54f373ccf864bf587a89e880fb7610f8d73f3045f13580948ccbcaff26febff"
 dependencies = [
  "dlopen2_derive",
  "libc",
@@ -798,9 +808,7 @@ dependencies = [
 
 [[package]]
 name = "dotnetrawfilereader-sys"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aa617a5390fd3e8459dd968086b872b89d849bc7d4a8e34b1a154bdb50b2b73"
+version = "0.5.3"
 dependencies = [
  "include_dir",
  "netcorehost",
@@ -951,11 +959,11 @@ dependencies = [
 
 [[package]]
 name = "flatbuffers"
-version = "23.5.26"
+version = "25.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dac53e22462d78c16d64a1cd22371b54cc3fe94aa15e7886a2fa6e5d1ab8640"
+checksum = "1045398c1bfd89168b5fd3f1fc11f6e70b34f6f66300c87d44d3de849463abf1"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.9.1",
  "rustc_version",
 ]
 
@@ -1305,9 +1313,9 @@ dependencies = [
 
 [[package]]
 name = "hostfxr-sys"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f03472152dee0240be92e7d776bd37b69995785acce08bc8defb884244158bb"
+checksum = "2d116fa54e808d6572c969818c2e36ec16eaa70ccd772955ef0f08a1ab8e5dc0"
 dependencies = [
  "coreclr-hosting-shared",
  "dlopen2",
@@ -2173,9 +2181,9 @@ dependencies = [
 
 [[package]]
 name = "netcorehost"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87b79d84cea554319a006af30e3fd687e69437d00efbd1541ea28601a273fa33"
+checksum = "696b63e1ed6aae6ac2a4e17377f7d82823306f5347aeeb928afdae47b35d5371"
 dependencies = [
  "coreclr-hosting-shared",
  "cstr",
@@ -2187,7 +2195,7 @@ dependencies = [
  "nethost-sys",
  "num_enum",
  "once_cell",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "widestring",
 ]
 
@@ -2319,14 +2327,12 @@ dependencies = [
 
 [[package]]
 name = "oci-spec"
-version = "0.6.8"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f5a3fe998d50101ae009351fec56d88a69f4ed182e11000e711068c2f5abf72"
+checksum = "bdf88ddc01cc6bccbe1044adb6a29057333f523deadcb4953c011a73158cfa5e"
 dependencies = [
  "derive_builder",
  "getset",
- "once_cell",
- "regex",
  "serde",
  "serde_json",
  "strum",
@@ -2363,9 +2369,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -3456,9 +3462,7 @@ dependencies = [
 
 [[package]]
 name = "thermorawfilereader"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23672085e9b1b63c8e0c30c71d7087f0e60b631e934014fbfba85a62daaec3da"
+version = "0.5.3"
 dependencies = [
  "bytemuck",
  "dotnetrawfilereader-sys",
@@ -3808,6 +3812,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,7 +171,7 @@ reqwest = { version = "0.12", features = ["json", "blocking"], optional = true }
 futures = { version = "0.3", optional = true }
 
 # Thermo RAW-related features
-thermorawfilereader = { version = "0.5.2", default-features = false, optional = true }
+thermorawfilereader = { version = "0.5.3", default-features = false, optional = true }
 
 # Bruker TDF-related features
 rusqlite = { version = "0.31.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,7 +171,7 @@ reqwest = { version = "0.12", features = ["json", "blocking"], optional = true }
 futures = { version = "0.3", optional = true }
 
 # Thermo RAW-related features
-thermorawfilereader = { version = "0.5.1", default-features = false, optional = true }
+thermorawfilereader = { version = "0.5.2", default-features = false, optional = true }
 
 # Bruker TDF-related features
 rusqlite = { version = "0.31.0", optional = true }

--- a/src/io/thermo/instruments.rs
+++ b/src/io/thermo/instruments.rs
@@ -82,6 +82,7 @@ pub enum InstrumentModelType {
     DFS,
     DSQ_II,
     ISQ,
+    ISQ_7000,
     MALDI_LTQ_XL,
     MALDI_LTQ_Orbitrap,
     TSQ_Quantum,
@@ -150,6 +151,7 @@ impl InstrumentModelType {
             InstrumentModelType::GC_IsoLink => param!("GC IsoLink", 1000648),
             InstrumentModelType::GC_Quantum => param!("GC Quantum", 1000558),
             InstrumentModelType::ISQ => param!("ISQ", 1001908),
+            InstrumentModelType::ISQ_7000 => param!("ISQ 7000", 1003449),
             InstrumentModelType::ITQ_1100 => param!("ITQ 1100", 1000637),
             InstrumentModelType::ITQ_700 => param!("ITQ 700", 1000635),
             InstrumentModelType::ITQ_900 => param!("ITQ 900", 1000636),
@@ -428,6 +430,7 @@ static INSTRUMENT_MODEL_TYPE_MATCH: [(&str, InstrumentModelType, MatchType); 89]
     ("DFS", InstrumentModelType::DFS, MatchType::Exact),
     ("DSQ II", InstrumentModelType::DSQ_II, MatchType::Exact),
     ("ISQ SERIES", InstrumentModelType::ISQ, MatchType::Exact),
+    ("ISQ 7000", InstrumentModelType::ISQ_7000, MatchType::Exact),
     (
         "MALDI LTQ XL",
         InstrumentModelType::MALDI_LTQ_XL,
@@ -684,6 +687,7 @@ pub fn instrument_model_to_mass_analyzers(model: InstrumentModelType) -> Vec<Mas
         | InstrumentModelType::DSQ
         | InstrumentModelType::DSQ_II
         | InstrumentModelType::ISQ
+        | InstrumentModelType::ISQ_7000
         | InstrumentModelType::Trace_DSQ
         | InstrumentModelType::GC_IsoLink => {
             vec![MassAnalyzerTerm::Quadrupole]
@@ -822,6 +826,7 @@ pub fn instrument_model_to_detector(model: InstrumentModelType) -> Vec<DetectorT
         InstrumentModelType::DSQ |
         InstrumentModelType::DSQ_II |
         InstrumentModelType::ISQ |
+        InstrumentModelType::ISQ_7000 |
         InstrumentModelType::Trace_DSQ |
         InstrumentModelType::GC_IsoLink => {
             vec![DetectorTypeTerm::ElectronMultiplier]
@@ -873,7 +878,7 @@ pub fn instrument_model_to_detector(model: InstrumentModelType) -> Vec<DetectorT
         }
 
         InstrumentModelType::Unknown => {
-            vec![]
+            vec![DetectorTypeTerm::Unknown]
         },
     }
 }
@@ -954,6 +959,9 @@ pub fn instrument_model_to_ion_sources(model: InstrumentModelType) -> Vec<Ioniza
         }
         InstrumentModelType::MALDI_LTQ_XL | InstrumentModelType::MALDI_LTQ_Orbitrap => {
             vec![IonizationTypeTerm::MatrixAssistedLaserDesorptionIonization]
+        }
+        InstrumentModelType::ISQ_7000 => {
+            vec![IonizationTypeTerm::ElectronIonization, IonizationTypeTerm::ChemicalIonization]
         }
         _ => Vec::default(),
     }
@@ -1140,6 +1148,7 @@ pub fn create_instrument_configurations(model: InstrumentModelType, source: Comp
         InstrumentModelType::DSQ |
         InstrumentModelType::DSQ_II |
         InstrumentModelType::ISQ |
+        InstrumentModelType::ISQ_7000 |
         InstrumentModelType::Trace_DSQ |
         InstrumentModelType::GC_IsoLink => {
             configs.push(InstrumentConfiguration::default());

--- a/src/io/thermo/instruments.rs
+++ b/src/io/thermo/instruments.rs
@@ -232,7 +232,7 @@ impl InstrumentModelType {
     }
 }
 
-static INSTRUMENT_MODEL_TYPE_MATCH: [(&str, InstrumentModelType, MatchType); 89] = [
+static INSTRUMENT_MODEL_TYPE_MATCH: [(&str, InstrumentModelType, MatchType); 90] = [
     (
         "MAT253",
         InstrumentModelType::MAT253,
@@ -878,7 +878,7 @@ pub fn instrument_model_to_detector(model: InstrumentModelType) -> Vec<DetectorT
         }
 
         InstrumentModelType::Unknown => {
-            vec![DetectorTypeTerm::Unknown]
+            vec![]
         },
     }
 }

--- a/src/io/thermo/reader.rs
+++ b/src/io/thermo/reader.rs
@@ -864,11 +864,16 @@ pub(crate) mod sealed {
             event.injection_time = vevent.injection_time();
             let window = ScanWindow::new(vevent.low_mz() as f32, vevent.high_mz() as f32);
             event.scan_windows.push(window);
-            if let Some(cv) = vevent.compensation_voltage() {
-                let mut param =
-                    ControlledVocabulary::MS.param_val(1001581, "FAIMS compensation voltage", cv);
-                param.unit = Unit::Volt;
-                event.add_param(param);
+            if let Some(cv) = vevent.compensation_voltages() {
+                for cv in cv.iter() {
+                    let mut param = ControlledVocabulary::MS.param_val(
+                        1001580,
+                        "FAIMS compensation voltage",
+                        cv,
+                    );
+                    param.unit = Unit::Volt;
+                    event.add_param(param);
+                }
             }
             if let Some(resolution) = vevent.resolution() {
                 event.add_param(ControlledVocabulary::MS.param_val(

--- a/src/spectrum/bindata/encodings.rs
+++ b/src/spectrum/bindata/encodings.rs
@@ -140,11 +140,11 @@ mod byte_rotation {
     }
 
     pub fn reverse_transpose_i64(data: &[u8]) -> Vec<u8> {
-        reverse_transpose_8bytes::<f64>(data)
+        reverse_transpose_8bytes::<i64>(data)
     }
 
     pub fn reverse_transpose_f64(data: &[u8]) -> Vec<u8> {
-        reverse_transpose_8bytes::<i64>(data)
+        reverse_transpose_8bytes::<f64>(data)
     }
 }
 


### PR DESCRIPTION
This adds support for parsing data from ISQ 7000 instruments (see https://github.com/HUPO-PSI/psi-ms-CV/pull/393 for the request for a new CV term).

Also adds support for reading multiple FAIMS offset voltages (as may happen with ramped voltages or SIM scans). This is breaking and requires https://github.com/mobiusklein/thermorawfilereader.rs/pull/2