### PR TITLE
fix(tdf): process_3d_slice mis-slices MS2/DIA frames (duplicates peaks at wrong mobility)

### DIFF
--- a/src/io/tdf/arrays.rs
+++ b/src/io/tdf/arrays.rs
@@ -47,7 +47,14 @@ impl<'a> FrameToArraysMapper<'a> {
         let mut im_dimension = Vec::with_capacity(final_scan - first_scan + 1);
         let mut arrays = Vec::with_capacity(final_scan - first_scan + 1);
 
-        let mut scan_begin = first_scan;
+        // `scan_offsets` is a cumulative prefix-sum into `tof_indices`/`intensities`
+        // (peak OFFSETS), not scan indices. `scan_begin` must therefore start at the
+        // offset of `first_scan`, not at the scan index itself. The two coincide only
+        // when `first_scan == 0` (MS1 / the first window), so every slice with
+        // `first_scan > 0` (all PASEF/DIA MS2 windows) previously read
+        // `tof_indices[first_scan .. scan_offsets[first_scan]]` on its first iteration
+        // — prepending all earlier scans' peaks, stamped with one wrong mobility.
+        let mut scan_begin = self.frame.scan_offsets[first_scan];
         for (i, mut scan_end) in self.frame.scan_offsets[first_scan..final_scan]
             .iter()
             .copied()

--- a/src/io/tdf/arrays.rs
+++ b/src/io/tdf/arrays.rs
@@ -47,13 +47,6 @@ impl<'a> FrameToArraysMapper<'a> {
         let mut im_dimension = Vec::with_capacity(final_scan - first_scan + 1);
         let mut arrays = Vec::with_capacity(final_scan - first_scan + 1);
 
-        // `scan_offsets` is a cumulative prefix-sum into `tof_indices`/`intensities`
-        // (peak OFFSETS), not scan indices. `scan_begin` must therefore start at the
-        // offset of `first_scan`, not at the scan index itself. The two coincide only
-        // when `first_scan == 0` (MS1 / the first window), so every slice with
-        // `first_scan > 0` (all PASEF/DIA MS2 windows) previously read
-        // `tof_indices[first_scan .. scan_offsets[first_scan]]` on its first iteration
-        // — prepending all earlier scans' peaks, stamped with one wrong mobility.
         let mut scan_begin = self.frame.scan_offsets[first_scan];
         for (i, mut scan_end) in self.frame.scan_offsets[first_scan..final_scan]
             .iter()

--- a/src/io/tdf/reader.rs
+++ b/src/io/tdf/reader.rs
@@ -578,12 +578,18 @@ impl<C: FeatureLike<MZ, IonMobility>, D: FeatureLike<Mass, IonMobility> + KnownC
 
             let arrays = if !matches!(self.detail_level, DetailLevel::MetadataOnly) {
                 if let Some(pasef) = entry.pasef_msms() {
-                    log::trace!("Extracting {index} as PasefFrameMsMs with range {:?}", pasef.scan_start..pasef.scan_end);
+                    log::trace!(
+                        "Extracting {index} as PasefFrameMsMs with range {:?}",
+                        pasef.scan_start..pasef.scan_end
+                    );
                     let arrays = FrameToArraysMapper::new(&frame, &self.metadata)
                         .process_3d_slice(pasef.scan_start..pasef.scan_end);
                     Some(arrays)
                 } else if let Some(dia_pasef) = entry.dia_window() {
-                    log::trace!("Extracting {index} as DIAFrameMsMsWindow with range {:?}", dia_pasef.scan_start..dia_pasef.scan_end);
+                    log::trace!(
+                        "Extracting {index} as DIAFrameMsMsWindow with range {:?}",
+                        dia_pasef.scan_start..dia_pasef.scan_end
+                    );
                     let arrays = FrameToArraysMapper::new(&frame, &self.metadata)
                         .process_3d_slice(dia_pasef.scan_start..dia_pasef.scan_end);
                     Some(arrays)
@@ -1282,7 +1288,10 @@ impl<
     pub fn consolidate_peaks(
         &self,
         spectrum: &mut MultiLayerSpectrum<CP, DP>,
-    ) -> Result<(), ArrayRetrievalError> where CP: From<CentroidPeak> {
+    ) -> Result<(), ArrayRetrievalError>
+    where
+        CP: From<CentroidPeak>,
+    {
         if let Some(arrays) = spectrum.arrays.as_ref() {
             let arrays = BinaryArrayMap3D::stack(arrays)?;
             spectrum.peaks = Some(consolidate_peaks(
@@ -1638,7 +1647,7 @@ mod test {
     fn test_tdf_frame() -> io::Result<()> {
         let mut reader = TDFFrameReader::new("test/data/diaPASEF.d")
             .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
-        eprintln!("{}", reader.len());
+
         let s = reader.get_frame_by_index(0).unwrap();
         assert!(s.features.is_none());
         assert_eq!(s.signal_continuity(), SignalContinuity::Centroid);
@@ -1648,6 +1657,43 @@ mod test {
         assert!(s.features.is_none());
         assert_eq!(s.signal_continuity(), SignalContinuity::Centroid);
         assert_eq!(s.ms_level(), 2);
+
+        // SQL: "SELECT NumPeaks FROM Frames;"
+        let mut expected_peak_counts = vec![205921usize, 9365, 10566, 10908, 54771];
+        let original_peak_counts = expected_peak_counts.clone();
+
+        for frame in reader.iter() {
+            let frame_idx = frame
+                .id()
+                .split(" ")
+                .skip(1)
+                .next()
+                .unwrap()
+                .split_once("=")
+                .unwrap()
+                .1
+                .parse::<usize>()
+                .unwrap()
+                - 1;
+
+            let vals = frame.raw_arrays().unwrap();
+            let vals_flat = vals.unstack().unwrap();
+            let n_flat = vals_flat.mzs().unwrap().len();
+            let n_stacked = vals
+                .arrays
+                .iter()
+                .map(|v| v.mzs().map(|v| v.len()).unwrap_or_default())
+                .sum::<usize>();
+            assert_eq!(n_flat, n_stacked);
+
+            // Assumes non-overlapping PASEF frames
+            assert!(
+                n_flat <= expected_peak_counts[frame_idx],
+                "Failed to count peaks properly: {} peaks out of {} remaining, claiming {n_flat} more",
+                expected_peak_counts[frame_idx], original_peak_counts[frame_idx]
+            );
+            expected_peak_counts[frame_idx] = expected_peak_counts[frame_idx] - n_flat;
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
I came across this issue when trying to process timsTOF files w/ mzdata to 
squeeze them into mzPeak. Surprisingly, the mzdata output generated more
peaks than the original tdf contained. 

It looks to me as if this here is the issue:

`FrameToArraysMapper::process_3d_slice` (`src/io/tdf/arrays.rs`) seeds `scan_begin` with the scan **index** `first_scan`, but `scan_offsets` is a cumulative prefix-sum of **peak offsets** into `tof_indices`/`intensities`. The two coincide only when `first_scan == 0`, so MS1 (and the first window) are correct, but **every slice with `first_scan > 0` — i.e. all PASEF/diaPASEF MS2 isolation windows — reads `tof_indices[first_scan .. scan_offsets[first_scan]]` on its first iteration.** That prepends every peak from the start of the frame up to the window, all stamped with a single wrong ion mobility.

Would you mind having a look at it at some point?
