### PR TITLE
chore: bump quick-xml 0.30 -> 0.41

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2767,9 +2767,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.30.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,7 +138,7 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
 serde_with = { version = "3.12.0", optional = true }
 
-quick-xml = { version = "0.30", features = ["serialize"], optional = true }
+quick-xml = { version = "0.41", features = ["serialize"], optional = true }
 uuid = { version = "1.0", features = ["v4", "serde"], optional = true }
 num-traits = "0.2"
 log = "0.4.20"

--- a/src/io/imzml/reader.rs
+++ b/src/io/imzml/reader.rs
@@ -91,7 +91,7 @@ pub fn is_imzml(buffer: &[u8]) -> bool {
                         for attr in e.attributes() {
                             if let Ok(attr) = attr {
                                 if attr.key.as_ref() == b"id" {
-                                    if let Ok(value) = attr.unescape_value() {
+                                    if let Ok(value) = attr.normalized_value(quick_xml::XmlVersion::Implicit1_0) {
                                         if value.as_ref() == "IMS" {
                                             return true;
                                         }
@@ -622,7 +622,7 @@ impl<
      */
     fn parse_metadata(&mut self) -> Result<(), MzMLParserError> {
         let mut reader = Reader::from_reader(&mut self.handle);
-        reader.trim_text(true);
+        reader.config_mut().trim_text(true);
         let mut accumulator = ImzmlMetadataBuilder {
             mzml_metadata_builder: FileMetadataBuilder {
                 instrument_id_map: Some(&mut self.instrument_id_map),
@@ -676,7 +676,7 @@ impl<
                     };
                 }
                 Ok(Event::Empty(ref e)) => {
-                    match accumulator.empty_element(e, self.state, reader.buffer_position()) {
+                    match accumulator.empty_element(e, self.state, reader.buffer_position() as usize) {
                         Ok(state) => {
                             self.state = state;
                         }
@@ -690,10 +690,10 @@ impl<
                     break;
                 }
                 Err(err) => match &err {
-                    XMLError::EndEventMismatch {
+                    XMLError::IllFormed(quick_xml::errors::IllFormedError::MismatchedEndTag {
                         expected,
                         found: _found,
-                    } => {
+                    }) => {
                         if expected.is_empty() && self.state == MzMLParserState::Resume {
                             continue;
                         } else {
@@ -800,7 +800,7 @@ impl<
         }
 
         let mut reader = Reader::from_reader(&mut self.handle);
-        reader.trim_text(true);
+        reader.config_mut().trim_text(true);
         accumulator = accumulator.borrow_metadata(&mut self.instrument_id_map, &mut self.reference_param_groups);
         accumulator.set_run_data_processing(self.run.default_data_processing_id.clone().map(|v| v.into_boxed_str()));
         let mut offset: usize = 0;
@@ -855,7 +855,7 @@ impl<
                     };
                 }
                 Ok(Event::Empty(ref e)) => {
-                    match accumulator.empty_element(e, self.state, reader.buffer_position()) {
+                    match accumulator.empty_element(e, self.state, reader.buffer_position() as usize) {
                         Ok(state) => {
                             self.state = state;
                         }
@@ -868,10 +868,10 @@ impl<
                     break;
                 }
                 Err(err) => match &err {
-                    XMLError::EndEventMismatch {
+                    XMLError::IllFormed(quick_xml::errors::IllFormedError::MismatchedEndTag {
                         expected,
                         found: _found,
-                    } => {
+                    }) => {
                         if expected.is_empty() && self.state == MzMLParserState::Resume {
                             continue;
                         } else {
@@ -1049,7 +1049,7 @@ impl<
             Err(err) => return Err(MzMLParserError::IOError(self.state, err)),
         };
         let mut reader = Reader::from_reader(&mut self.handle);
-        reader.trim_text(true);
+        reader.config_mut().trim_text(true);
         let matched_tag = match reader.read_event_into(&mut self.buffer) {
             Ok(event) => match event {
                 Event::Start(ref e) => {

--- a/src/io/mzml/async_reader.rs
+++ b/src/io/mzml/async_reader.rs
@@ -160,7 +160,7 @@ impl<
      */
     async fn parse_metadata(&mut self) -> Result<(), MzMLParserError> {
         let mut reader = Reader::from_reader(&mut self.handle);
-        reader.trim_text(true);
+        reader.config_mut().trim_text(true);
         let mut accumulator = FileMetadataBuilder {
             instrument_id_map: Some(&mut self.instrument_id_map),
             ..Default::default()
@@ -207,7 +207,7 @@ impl<
                     };
                 }
                 Ok(Event::Empty(ref e)) => {
-                    match accumulator.empty_element(e, self.state, reader.buffer_position()) {
+                    match accumulator.empty_element(e, self.state, reader.buffer_position() as usize) {
                         Ok(state) => {
                             self.state = state;
                         }
@@ -221,10 +221,10 @@ impl<
                     break;
                 }
                 Err(err) => match &err {
-                    XMLError::EndEventMismatch {
+                    XMLError::IllFormed(quick_xml::errors::IllFormedError::MismatchedEndTag {
                         expected,
                         found: _found,
-                    } => {
+                    }) => {
                         if expected.is_empty() && self.state == MzMLParserState::Resume {
                             continue;
                         } else {
@@ -291,7 +291,7 @@ impl<
         mut accumulator: MzMLSpectrumBuilder<'a, C, D>,
     ) -> Result<(usize, MzMLSpectrumBuilder<'a, C, D>), MzMLParserError> {
         let mut reader = Reader::from_reader(&mut self.handle);
-        reader.trim_text(true);
+        reader.config_mut().trim_text(true);
         accumulator.instrument_id_map = Some(&mut self.instrument_id_map);
         if let Some(val) = self.run.default_data_processing_id.as_ref() {
             accumulator.set_run_data_processing(Some(val.clone().into()));
@@ -346,7 +346,7 @@ impl<
                     };
                 }
                 Ok(Event::Empty(ref e)) => {
-                    match accumulator.empty_element(e, self.state, reader.buffer_position()) {
+                    match accumulator.empty_element(e, self.state, reader.buffer_position() as usize) {
                         Ok(state) => {
                             self.state = state;
                         }
@@ -362,10 +362,10 @@ impl<
                     break;
                 }
                 Err(err) => match &err {
-                    XMLError::EndEventMismatch {
+                    XMLError::IllFormed(quick_xml::errors::IllFormedError::MismatchedEndTag {
                         expected,
                         found: _found,
-                    } => {
+                    }) => {
                         if expected.is_empty() && self.state == MzMLParserState::Resume {
                             continue;
                         } else {
@@ -592,7 +592,7 @@ impl IndexedMzMLIndexExtractor {
                         Ok(attr) => {
                             if attr.key.as_ref() == b"idRef" {
                                 self.last_id = attr
-                                    .unescape_value()
+                                    .normalized_value(quick_xml::XmlVersion::Implicit1_0)
                                     .expect("Error decoding idRef")
                                     .to_string();
                             }
@@ -609,7 +609,7 @@ impl IndexedMzMLIndexExtractor {
                         Ok(attr) => {
                             if attr.key.as_ref() == b"name" {
                                 let index_name = attr
-                                    .unescape_value()
+                                    .normalized_value(quick_xml::XmlVersion::Implicit1_0)
                                     .expect("Error decoding idRef")
                                     .to_string();
                                 match index_name.as_ref() {
@@ -656,8 +656,10 @@ impl IndexedMzMLIndexExtractor {
     ) -> Result<IndexParserState, XMLError> {
         match state {
             IndexParserState::SpectrumIndexList => {
-                let bin = event
-                    .unescape()
+                let decoded = event
+                    .decode()
+                    .expect("Failed to decode spectrum offset");
+                let bin = quick_xml::escape::unescape(&decoded)
                     .expect("Failed to unescape spectrum offset");
                 if let Ok(offset) = bin.parse::<u64>() {
                     if !self.last_id.is_empty() {
@@ -669,8 +671,10 @@ impl IndexedMzMLIndexExtractor {
                 }
             }
             IndexParserState::ChromatogramIndexList => {
-                let bin = event
-                    .unescape()
+                let decoded = event
+                    .decode()
+                    .expect("Failed to decode chromatogram offset");
+                let bin = quick_xml::escape::unescape(&decoded)
                     .expect("Failed to unescape chromatogram offset");
                 if let Ok(offset) = bin.parse::<u64>() {
                     if !self.last_id.is_empty() {
@@ -739,7 +743,7 @@ impl<
             .expect("Failed to seek to the index offset");
 
         let mut reader = Reader::from_reader(&mut self.handle);
-        reader.trim_text(true);
+        reader.config_mut().trim_text(true);
 
         loop {
             match reader.read_event_into_async(&mut self.buffer).await {

--- a/src/io/mzml/reader.rs
+++ b/src/io/mzml/reader.rs
@@ -781,7 +781,7 @@ impl<C: CentroidLike + BuildFromArrayMap, D: DeconvolutedCentroidLike + BuildFro
                     match attr_parsed {
                         Ok(attr) => match attr.key.as_ref() {
                             b"id" => {
-                                self.entry_id = match attr.unescape_value()
+                                self.entry_id = match attr.normalized_value(quick_xml::XmlVersion::Implicit1_0)
                                     .map(|v| v.to_string())
                                     .or_else(|_| -> Result<String, quick_xml::Error> {
                                         log::trace!("Detected non-UTF8 character in spectrum id");
@@ -833,10 +833,10 @@ impl<C: CentroidLike + BuildFromArrayMap, D: DeconvolutedCentroidLike + BuildFro
                                     .instrument_id_map
                                     .as_mut()
                                     .expect("An instrument ID map was not provided")
-                                    .get(&attr.unescape_value().expect("Error decoding id"));
+                                    .get(&attr.normalized_value(quick_xml::XmlVersion::Implicit1_0).expect("Error decoding id"));
                             } else if attr.key.as_ref() == b"spectrumRef" {
                                 let sref =
-                                    attr.unescape_value().expect("Error decoding spectrumRef");
+                                    attr.normalized_value(quick_xml::XmlVersion::Implicit1_0).expect("Error decoding spectrumRef");
                                 scan_event.spectrum_reference = Some(sref.into());
                             }
                         }
@@ -871,7 +871,7 @@ impl<C: CentroidLike + BuildFromArrayMap, D: DeconvolutedCentroidLike + BuildFro
                         Ok(attr) => {
                             if attr.key.as_ref() == b"spectrumRef" {
                                 self.precursor_mut().precursor_id = Some(
-                                    attr.unescape_value()
+                                    attr.normalized_value(quick_xml::XmlVersion::Implicit1_0)
                                         .expect("Error decoding id")
                                         .to_string(),
                                 );
@@ -916,7 +916,7 @@ impl<C: CentroidLike + BuildFromArrayMap, D: DeconvolutedCentroidLike + BuildFro
                     match attr_parsed {
                         Ok(attr) => {
                             if attr.key.as_ref() == b"dataProcessingRef" {
-                                match attr.unescape_value() {
+                                match attr.normalized_value(quick_xml::XmlVersion::Implicit1_0) {
                                     Ok(v) => {
                                         self.current_array.set_data_processing_reference(Some(v.into()));
                                         dp_set = true;
@@ -953,7 +953,7 @@ impl<C: CentroidLike + BuildFromArrayMap, D: DeconvolutedCentroidLike + BuildFro
                         Ok(attr) => match attr.key.as_ref() {
                             b"id" => {
                                 self.entry_id = attr
-                                    .unescape_value()
+                                    .normalized_value(quick_xml::XmlVersion::Implicit1_0)
                                     .map(|v| v.to_string())
                                     .or_else(|_| -> Result<String, quick_xml::Error> {
                                         log::trace!("Detected non-UTF8 character in chromatogram id");
@@ -995,7 +995,7 @@ impl<C: CentroidLike + BuildFromArrayMap, D: DeconvolutedCentroidLike + BuildFro
                         Ok(attr) => {
                             if attr.key.as_ref() == b"ref" {
                                 let group_id = attr
-                                    .unescape_value()
+                                    .normalized_value(quick_xml::XmlVersion::Implicit1_0)
                                     .expect("Error decoding reference group")
                                     .to_string();
                                 if let Some(ref_param_groups) = self.reference_param_groups {
@@ -1190,9 +1190,11 @@ impl<C: CentroidLike + BuildFromArrayMap, D: DeconvolutedCentroidLike + BuildFro
 
     fn text(&mut self, event: &BytesText, state: MzMLParserState) -> ParserResult {
         if state == MzMLParserState::Binary && self.detail_level != DetailLevel::MetadataOnly {
-            let bin = event
-                .unescape()
-                .map_err(|e| MzMLParserError::XMLError(state, e))?;
+            let decoded = event
+                .decode()
+                .map_err(|e| MzMLParserError::XMLError(state, e.into()))?;
+            let bin = quick_xml::escape::unescape(&decoded)
+                .map_err(|e| MzMLParserError::XMLError(state, e.into()))?;
             self.current_array.data = Bytes::from(bin.as_bytes());
         }
         Ok(state)
@@ -1384,7 +1386,7 @@ impl<
      */
     fn parse_metadata(&mut self) -> Result<(), MzMLParserError> {
         let mut reader = Reader::from_reader(&mut self.handle);
-        reader.trim_text(true);
+        reader.config_mut().trim_text(true);
         let mut accumulator = FileMetadataBuilder {
             instrument_id_map: Some(&mut self.instrument_id_map),
             ..Default::default()
@@ -1435,7 +1437,7 @@ impl<
                     };
                 }
                 Ok(Event::Empty(ref e)) => {
-                    match accumulator.empty_element(e, self.state, reader.buffer_position()) {
+                    match accumulator.empty_element(e, self.state, reader.buffer_position() as usize) {
                         Ok(state) => {
                             self.state = state;
                         }
@@ -1449,10 +1451,10 @@ impl<
                     break;
                 }
                 Err(err) => match &err {
-                    XMLError::EndEventMismatch {
+                    XMLError::IllFormed(quick_xml::errors::IllFormedError::MismatchedEndTag {
                         expected,
                         found: _found,
-                    } => {
+                    }) => {
                         if expected.is_empty() && self.state == MzMLParserState::Resume {
                             continue;
                         } else {
@@ -1524,7 +1526,7 @@ impl<
         }
 
         let mut reader = Reader::from_reader(&mut self.handle);
-        reader.trim_text(true);
+        reader.config_mut().trim_text(true);
         let mut accumulator = accumulator
             .borrow_metadata(&mut self.instrument_id_map, &self.reference_param_groups);
         accumulator.set_run_data_processing(self.run.default_data_processing_id.clone().map(|v| v.into_boxed_str()));
@@ -1580,7 +1582,7 @@ impl<
                     };
                 }
                 Ok(Event::Empty(ref e)) => {
-                    match accumulator.empty_element(e, self.state, reader.buffer_position()) {
+                    match accumulator.empty_element(e, self.state, reader.buffer_position() as usize) {
                         Ok(state) => {
                             self.state = state;
                         }
@@ -1593,10 +1595,10 @@ impl<
                     break;
                 }
                 Err(err) => match &err {
-                    XMLError::EndEventMismatch {
+                    XMLError::IllFormed(quick_xml::errors::IllFormedError::MismatchedEndTag {
                         expected,
                         found: _found,
-                    } => {
+                    }) => {
                         if expected.is_empty() && self.state == MzMLParserState::Resume {
                             continue;
                         } else {
@@ -1772,7 +1774,7 @@ impl<
             Err(err) => return Err(MzMLParserError::IOError(self.state, err)),
         };
         let mut reader = Reader::from_reader(&mut self.handle);
-        reader.trim_text(true);
+        reader.config_mut().trim_text(true);
         let matched_tag = match reader.read_event_into(&mut self.buffer) {
             Ok(event) => match event {
                 Event::Start(ref e) => {
@@ -2175,7 +2177,7 @@ impl<
             .expect("Failed to seek to the index offset");
 
         let mut reader = Reader::from_reader(&mut self.handle);
-        reader.trim_text(true);
+        reader.config_mut().trim_text(true);
 
         loop {
             match reader.read_event_into(&mut self.buffer) {

--- a/src/io/mzml/reading_shared.rs
+++ b/src/io/mzml/reading_shared.rs
@@ -186,7 +186,7 @@ pub trait CVParamParse: XMLParseBase {
             match attr_parsed {
                 Ok(attr) => match attr.key.as_ref() {
                     b"name" => {
-                        name = Some(attr.unescape_value().or_else(|_| {
+                        name = Some(attr.normalized_value(quick_xml::XmlVersion::Implicit1_0).or_else(|_| {
                             log::debug!("Non-UTF-8 detected in parameter name at {reader_position} in state {state}");
                             Ok(decode_latin1_escape(&attr.value).into())
                         }).unwrap_or_else(|e: quick_xml::Error| {
@@ -194,7 +194,7 @@ pub trait CVParamParse: XMLParseBase {
                         }));
                     }
                     b"value" => {
-                        value = Some(attr.unescape_value().or_else(|_| {
+                        value = Some(attr.normalized_value(quick_xml::XmlVersion::Implicit1_0).or_else(|_| {
                             log::debug!("Non-UTF-8 detected in parameter value at {reader_position} in state {state}");
                             Ok(decode_latin1_escape(&attr.value).into())
                         }).unwrap_or_else(|e: quick_xml::Error| {
@@ -205,7 +205,7 @@ pub trait CVParamParse: XMLParseBase {
                         }));
                     }
                     b"cvRef" => {
-                        let cv_id = attr.unescape_value().unwrap_or_else(|e| {
+                        let cv_id = attr.normalized_value(quick_xml::XmlVersion::Implicit1_0).unwrap_or_else(|e| {
                             panic!(
                                 "Error decoding CV param reference at {}: {}",
                                 reader_position, e
@@ -219,7 +219,7 @@ pub trait CVParamParse: XMLParseBase {
                             .as_option();
                     }
                     b"accession" => {
-                        let v = attr.unescape_value().unwrap_or_else(|e| {
+                        let v = attr.normalized_value(quick_xml::XmlVersion::Implicit1_0).unwrap_or_else(|e| {
                             panic!(
                                 "Error decoding CV param accession at {}: {}",
                                 reader_position, e
@@ -229,7 +229,7 @@ pub trait CVParamParse: XMLParseBase {
                         accession = acc;
                     }
                     b"unitName" => {
-                        let v = attr.unescape_value().or_else(|_| {
+                        let v = attr.normalized_value(quick_xml::XmlVersion::Implicit1_0).or_else(|_| {
                             log::debug!("Non-UTF-8 detected in parameter unit name at {reader_position} in state {state}");
                             Ok(decode_latin1_escape(&attr.value).into())
                         }).unwrap_or_else(|e: quick_xml::Error| {
@@ -241,7 +241,7 @@ pub trait CVParamParse: XMLParseBase {
                         unit = Unit::from_name(&v);
                     }
                     b"unitAccession" => {
-                        let v = attr.unescape_value().unwrap_or_else(|e| {
+                        let v = attr.normalized_value(quick_xml::XmlVersion::Implicit1_0).unwrap_or_else(|e| {
                             panic!(
                                 "Error decoding CV param unit name at {}: {}",
                                 reader_position, e
@@ -278,7 +278,7 @@ pub trait CVParamParse: XMLParseBase {
                 Ok(attr) => match attr.key.as_ref() {
                     b"name" => {
                         param.name = attr
-                            .unescape_value()
+                            .normalized_value(quick_xml::XmlVersion::Implicit1_0)
                             .or_else(|_| {
                                 log::debug!("Non-UTF-8 detected in parameter name at {reader_position} in state {state}");
                                 Ok(decode_latin1_escape(&attr.value).into())
@@ -290,7 +290,7 @@ pub trait CVParamParse: XMLParseBase {
                     }
                     b"value" => {
                         param.value = attr
-                            .unescape_value()
+                            .normalized_value(quick_xml::XmlVersion::Implicit1_0)
                             .or_else(|_| {
                                 log::debug!("Non-UTF-8 detected in parameter value at {reader_position} in state {state}");
                                 Ok(decode_latin1_escape(&attr.value).into())
@@ -304,7 +304,7 @@ pub trait CVParamParse: XMLParseBase {
                             .into();
                     }
                     b"cvRef" => {
-                        let cv_id = attr.unescape_value().unwrap_or_else(|e| {
+                        let cv_id = attr.normalized_value(quick_xml::XmlVersion::Implicit1_0).unwrap_or_else(|e| {
                             panic!(
                                 "Error decoding CV param reference at {}: {}",
                                 reader_position, e
@@ -318,7 +318,7 @@ pub trait CVParamParse: XMLParseBase {
                             .as_option();
                     }
                     b"accession" => {
-                        let v = attr.unescape_value().unwrap_or_else(|e| {
+                        let v = attr.normalized_value(quick_xml::XmlVersion::Implicit1_0).unwrap_or_else(|e| {
                             panic!(
                                 "Error decoding CV param accession at {}: {}",
                                 reader_position, e
@@ -328,7 +328,7 @@ pub trait CVParamParse: XMLParseBase {
                         param.accession = acc;
                     }
                     b"unitName" => {
-                        let v = attr.unescape_value().or_else(|_| {
+                        let v = attr.normalized_value(quick_xml::XmlVersion::Implicit1_0).or_else(|_| {
                             log::debug!("Non-UTF-8 detected in parameter unit name at {reader_position} in state {state}");
                             Ok(decode_latin1_escape(&attr.value).into())
                         }).unwrap_or_else(|e: quick_xml::Error| {
@@ -340,7 +340,7 @@ pub trait CVParamParse: XMLParseBase {
                         unit_name = Some(Unit::from_name(&v));
                     }
                     b"unitAccession" => {
-                        let v = attr.unescape_value().unwrap_or_else(|e| {
+                        let v = attr.normalized_value(quick_xml::XmlVersion::Implicit1_0).unwrap_or_else(|e| {
                             panic!(
                                 "Error decoding CV param unit name at {}: {}",
                                 reader_position, e
@@ -493,7 +493,7 @@ impl IndexedMzMLIndexExtractor {
                         Ok(attr) => {
                             if attr.key.as_ref() == b"idRef" {
                                 self.last_id = attr
-                                    .unescape_value()
+                                    .normalized_value(quick_xml::XmlVersion::Implicit1_0)
                                     .map(|v| v.to_string())
                                     .or_else(|_| -> Result<String, quick_xml::Error> {
                                         log::trace!("Detected non-UTF8 character in idRef");
@@ -516,7 +516,7 @@ impl IndexedMzMLIndexExtractor {
                         Ok(attr) => {
                             if attr.key.as_ref() == b"name" {
                                 let index_name = attr
-                                    .unescape_value()
+                                    .normalized_value(quick_xml::XmlVersion::Implicit1_0)
                                     .expect("Error decoding idRef")
                                     .to_string();
                                 match index_name.as_ref() {
@@ -567,8 +567,10 @@ impl IndexedMzMLIndexExtractor {
     ) -> Result<IndexParserState, XMLError> {
         match state {
             IndexParserState::SpectrumIndexList => {
-                let bin = event
-                    .unescape()
+                let decoded = event
+                    .decode()
+                    .expect("Failed to decode spectrum offset");
+                let bin = quick_xml::escape::unescape(&decoded)
                     .expect("Failed to unescape spectrum offset");
                 if let Ok(offset) = bin.parse::<u64>() {
                     if !self.last_id.is_empty() {
@@ -580,8 +582,10 @@ impl IndexedMzMLIndexExtractor {
                 }
             }
             IndexParserState::ChromatogramIndexList => {
-                let bin = event
-                    .unescape()
+                let decoded = event
+                    .decode()
+                    .expect("Failed to decode chromatogram offset");
+                let bin = quick_xml::escape::unescape(&decoded)
                     .expect("Failed to unescape chromatogram offset");
                 if let Ok(offset) = bin.parse::<u64>() {
                     if !self.last_id.is_empty() {
@@ -640,17 +644,17 @@ impl FileMetadataBuilder<'_> {
                         Ok(attr) => {
                             if attr.key.as_ref() == b"id" {
                                 source_file.id = attr
-                                    .unescape_value()
+                                    .normalized_value(quick_xml::XmlVersion::Implicit1_0)
                                     .expect("Error decoding id")
                                     .to_string();
                             } else if attr.key.as_ref() == b"name" {
                                 source_file.name = attr
-                                    .unescape_value()
+                                    .normalized_value(quick_xml::XmlVersion::Implicit1_0)
                                     .expect("Error decoding name")
                                     .to_string();
                             } else if attr.key.as_ref() == b"location" {
                                 source_file.location = attr
-                                    .unescape_value()
+                                    .normalized_value(quick_xml::XmlVersion::Implicit1_0)
                                     .expect("Error decoding location")
                                     .to_string();
                             }
@@ -671,12 +675,12 @@ impl FileMetadataBuilder<'_> {
                         Ok(attr) => {
                             if attr.key.as_ref() == b"id" {
                                 software.id = attr
-                                    .unescape_value()
+                                    .normalized_value(quick_xml::XmlVersion::Implicit1_0)
                                     .expect("Error decoding id")
                                     .to_string();
                             } else if attr.key.as_ref() == b"version" {
                                 software.version = attr
-                                    .unescape_value()
+                                    .normalized_value(quick_xml::XmlVersion::Implicit1_0)
                                     .expect("Error decoding version")
                                     .to_string();
                             }
@@ -698,7 +702,7 @@ impl FileMetadataBuilder<'_> {
                         Ok(attr) => {
                             if attr.key.as_ref() == b"id" {
                                 let key = attr
-                                    .unescape_value()
+                                    .normalized_value(quick_xml::XmlVersion::Implicit1_0)
                                     .expect("Error decoding id")
                                     .to_string();
                                 self.reference_param_groups.entry(key.clone()).or_default();
@@ -726,7 +730,7 @@ impl FileMetadataBuilder<'_> {
                                     .as_mut()
                                     .expect("An instrument ID map was not provided")
                                     .get(
-                                        attr.unescape_value().expect("Error decoding id").as_ref(),
+                                        attr.normalized_value(quick_xml::XmlVersion::Implicit1_0).expect("Error decoding id").as_ref(),
                                     );
                             }
                         }
@@ -749,7 +753,7 @@ impl FileMetadataBuilder<'_> {
                         Ok(attr) => {
                             if attr.key.as_ref() == b"order" {
                                 source.order = attr
-                                    .unescape_value()
+                                    .normalized_value(quick_xml::XmlVersion::Implicit1_0)
                                     .expect("Error decoding order")
                                     .parse()
                                     .expect("Failed to parse integer from `order`");
@@ -777,7 +781,7 @@ impl FileMetadataBuilder<'_> {
                         Ok(attr) => {
                             if attr.key.as_ref() == b"order" {
                                 analyzer.order = attr
-                                    .unescape_value()
+                                    .normalized_value(quick_xml::XmlVersion::Implicit1_0)
                                     .expect("Error decoding order")
                                     .parse()
                                     .expect("Failed to parse integer from `order`");
@@ -805,7 +809,7 @@ impl FileMetadataBuilder<'_> {
                         Ok(attr) => {
                             if attr.key.as_ref() == b"order" {
                                 detector.order = attr
-                                    .unescape_value()
+                                    .normalized_value(quick_xml::XmlVersion::Implicit1_0)
                                     .expect("Error decoding order")
                                     .parse()
                                     .expect("Failed to parse integer from `order`");
@@ -831,12 +835,12 @@ impl FileMetadataBuilder<'_> {
                         Ok(attr) => {
                             if attr.key.as_ref() == b"id" {
                                 sample.id = attr
-                                    .unescape_value()
+                                    .normalized_value(quick_xml::XmlVersion::Implicit1_0)
                                     .expect("Error decoding id")
                                     .to_string();
                             } else if attr.key.as_ref() == b"name" {
                                 sample.name = Some(
-                                    attr.unescape_value()
+                                    attr.normalized_value(quick_xml::XmlVersion::Implicit1_0)
                                         .expect("Error decoding name")
                                         .to_string(),
                                 );
@@ -859,7 +863,7 @@ impl FileMetadataBuilder<'_> {
                         Ok(attr) => {
                             if attr.key.as_ref() == b"id" {
                                 dp.id = attr
-                                    .unescape_value()
+                                    .normalized_value(quick_xml::XmlVersion::Implicit1_0)
                                     .expect("Error decoding id")
                                     .to_string();
                                 has_id = true;
@@ -883,13 +887,13 @@ impl FileMetadataBuilder<'_> {
                         Ok(attr) => {
                             if attr.key.as_ref() == b"order" {
                                 method.order = attr
-                                    .unescape_value()
+                                    .normalized_value(quick_xml::XmlVersion::Implicit1_0)
                                     .expect("Error decoding order")
                                     .parse()
                                     .expect("Failed to parse order");
                             } else if attr.key.as_ref() == b"softwareRef" {
                                 method.software_reference = attr
-                                    .unescape_value()
+                                    .normalized_value(quick_xml::XmlVersion::Implicit1_0)
                                     .expect("Error decoding softwareRef")
                                     .to_string();
                             }
@@ -912,7 +916,7 @@ impl FileMetadataBuilder<'_> {
                     match attr.key.as_ref() {
                         b"id" => {
                             self.run_id = Some(
-                                attr.unescape_value()
+                                attr.normalized_value(quick_xml::XmlVersion::Implicit1_0)
                                     .expect("Error decoding run ID")
                                     .to_string(),
                             );
@@ -920,21 +924,21 @@ impl FileMetadataBuilder<'_> {
                         }
                         b"defaultInstrumentConfigurationRef" => {
                             let value = attr
-                                .unescape_value()
+                                .normalized_value(quick_xml::XmlVersion::Implicit1_0)
                                 .expect("Error decoding default instrument configuration ID");
                             self.default_instrument_config =
                                 self.instrument_id_map.as_mut().map(|m| m.get(&value));
                         }
                         b"defaultSourceFileRef" => {
                             self.default_source_file = Some(
-                                attr.unescape_value()
+                                attr.normalized_value(quick_xml::XmlVersion::Implicit1_0)
                                     .expect("Error decoding default source file reference")
                                     .to_string(),
                             );
                         }
                         b"startTimeStamp" => {
                             let val = attr
-                                .unescape_value()
+                                .normalized_value(quick_xml::XmlVersion::Implicit1_0)
                                 .expect("Error decoding start timestamp");
                             let val = DateTime::parse_from_rfc3339(&val).inspect_err(
                                 |&e| {
@@ -955,7 +959,7 @@ impl FileMetadataBuilder<'_> {
                 for attr in event.attributes().flatten() {
                     match attr.key.as_ref() {
                         b"count" => {
-                            self.num_spectra = attr.unescape_value()
+                            self.num_spectra = attr.normalized_value(quick_xml::XmlVersion::Implicit1_0)
                                     .expect("Error decoding spectrum list size")
                                     .parse()
                                     .map_err(|e| {
@@ -965,7 +969,7 @@ impl FileMetadataBuilder<'_> {
                         }
                         b"defaultDataProcessingRef" => {
                             let value = attr
-                                .unescape_value()
+                                .normalized_value(quick_xml::XmlVersion::Implicit1_0)
                                 .expect("Error decoding default instrument configuration ID");
                             self.default_data_processing = Some(value.to_string())
                         }
@@ -985,7 +989,7 @@ impl FileMetadataBuilder<'_> {
                         Ok(attr) => {
                             if attr.key.as_ref() == b"id" {
                                 settings.id = attr
-                                    .unescape_value()
+                                    .normalized_value(quick_xml::XmlVersion::Implicit1_0)
                                     .expect("Error decoding id")
                                     .to_string();
                                 has_id = true;
@@ -1103,7 +1107,7 @@ impl FileMetadataBuilder<'_> {
                             Ok(attr) => {
                                 if attr.key.as_ref() == b"ref" {
                                     ic.software_reference = attr
-                                        .unescape_value()
+                                        .normalized_value(quick_xml::XmlVersion::Implicit1_0)
                                         .expect("Error decoding software reference")
                                         .to_string();
                                 }
@@ -1121,7 +1125,7 @@ impl FileMetadataBuilder<'_> {
                         Ok(attr) => {
                             if attr.key.as_ref() == b"ref" {
                                 let group_id = attr
-                                    .unescape_value()
+                                    .normalized_value(quick_xml::XmlVersion::Implicit1_0)
                                     .expect("Error decoding reference group")
                                     .to_string();
 
@@ -1151,7 +1155,7 @@ impl FileMetadataBuilder<'_> {
                             Ok(attr) => {
                                 if attr.key.as_ref() == b"ref" {
                                     settings.source_file_refs.push(attr
-                                        .unescape_value()
+                                        .normalized_value(quick_xml::XmlVersion::Implicit1_0)
                                         .expect("Error decoding software reference")
                                         .to_string());
                                 }
@@ -1261,7 +1265,7 @@ pub fn build_spectrum_index<R: SeekRead>(
     handle.seek(SeekFrom::Start(0))
         .expect("Failed to reset stream to beginning");
     let mut reader = Reader::from_reader(&mut *handle);
-    reader.trim_text(true);
+    reader.config_mut().trim_text(true);
     loop {
         match reader.read_event_into(buffer) {
             Ok(Event::Start(ref e)) => {
@@ -1273,13 +1277,13 @@ pub fn build_spectrum_index<R: SeekRead>(
                             Ok(attr) => {
                                 if attr.key.as_ref() == b"id" {
                                     let scan_id = attr
-                                        .unescape_value()
+                                        .normalized_value(quick_xml::XmlVersion::Implicit1_0)
                                         .expect("Error decoding spectrum id in streaming index")
                                         .to_string();
                                     // This count is off by 2 because somehow the < and > bytes are removed?
                                     spectrum_index.insert(
                                         scan_id,
-                                        (reader.buffer_position() - e.len() - 2) as u64,
+                                        reader.buffer_position() - e.len() as u64 - 2,
                                     );
                                     break;
                                 };
@@ -1302,7 +1306,7 @@ pub fn build_spectrum_index<R: SeekRead>(
         };
         buffer.clear();
     }
-    let offset = reader.buffer_position() as u64;
+    let offset = reader.buffer_position();
     trace!("Ended indexing scan at offset {offset}. Restoring starting position {start}");
     handle
         .seek(SeekFrom::Start(start))

--- a/src/io/mzml/writer.rs
+++ b/src/io/mzml/writer.rs
@@ -49,7 +49,7 @@ macro_rules! attrib {
         let value = $value.as_bytes();
         // Because quick_xml::escape does not escape newlines
         let decoded = unsafe { std::str::from_utf8_unchecked(&value) };
-        let escaped_value = escape::escape(&decoded);
+        let escaped_value = escape::escape(decoded);
         $elt.push_attribute((key, escaped_value.as_bytes()));
     }};
 }


### PR DESCRIPTION
`cargo audit` flags the pinned quick-xml 0.30 for RUSTSEC-2026-0194/0195. 0195 doesn't apply here (this crate only uses the plain `Reader`, never `NsReader`, which is what that one's about). 0194 is a quadratic cost in duplicate-attribute-name checking on a single start tag - exploitable in principle with a tag containing a very large number of attributes, but a fairly narrow scenario in practice for typical mzML/imzML input. Bumping mainly to clear the audit warning and stay current; not filing this as an urgent security report.

Migration notes (0.41 is a breaking bump):

- `escape::escape()` no longer accepts `&&str` - one fix in `writer.rs`'s `attrib!` macro (accounts for most of the diff, since it's used throughout the mzML writer).
- `Reader::trim_text()` moved to `Reader::config_mut().trim_text()`.
- `BytesText::unescape()` was removed; replaced with `decode()` + `escape::unescape()`, which is what `unescape()` did internally (decode via the reader's `Decoder`, then unescape XML entities) - same behavior.
- `Attribute::unescape_value()` is deprecated in favor of `normalized_value(XmlVersion::Implicit1_0)`, which is what it delegates to internally - like-for-like swap.
- `Error::EndEventMismatch` moved under `Error::IllFormed(IllFormedError::MismatchedEndTag { .. })`; field names/types unchanged.
- `Reader::buffer_position()` changed from `usize` to `u64`; added casts at the two call sites that need it.

Tested locally, including `mzmlb` (needed a local cmake to build its hdf5/blosc deps, otherwise unrelated to this change): full test suite passes across mzml/imzml/async/parallelism/mgf/mzmlb (91+82 unit + 6 integration + 28 doc-tests across the two runs), including the round-trip base64 peak-data tests that exercise the text-decoding paths touched here. `cargo audit` no longer reports either advisory.
