### PR TITLE
CI: publish pymzdata to PyPI on release

### DIFF
--- a/.github/workflows/release-pymzdata.yml
+++ b/.github/workflows/release-pymzdata.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        target: [x64, x86]
+        target: [x64]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/release-pymzdata.yml
+++ b/.github/workflows/release-pymzdata.yml
@@ -1,0 +1,118 @@
+name: Release pymzdata
+
+# Build the crates/pymzdata wheels + sdist and publish them to PyPI, so downstreams users can
+# `pip install pymzdata` without a Rust toolchain. Mirrors the maturin-action layout used by the
+# ms2rescore-rs, with two crate-specific  additions: the `-m crates/pymzdata/Cargo.toml` manifest
+# (pymzdata is a sub-crate) and a cmake install for the zlib-ng-compat mzdata feature.
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  MANIFEST: crates/pymzdata/Cargo.toml
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [x86_64, aarch64]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist --find-interpreter -m ${{ env.MANIFEST }}
+          sccache: "true"
+          manylinux: auto
+          # pymzdata pulls the zlib-ng-compat mzdata feature; its libz-ng-sys build needs cmake.
+          before-script-linux: command -v cmake >/dev/null || (yum install -y cmake || dnf install -y cmake || (apt-get update && apt-get install -y cmake))
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-linux-${{ matrix.target }}
+          path: dist
+
+  windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        target: [x64, x86]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          architecture: ${{ matrix.target }}
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist --find-interpreter -m ${{ env.MANIFEST }}
+          sccache: "true"
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-windows-${{ matrix.target }}
+          path: dist
+
+  macos:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        target: [x86_64, aarch64]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist --find-interpreter -m ${{ env.MANIFEST }}
+          sccache: "true"
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-macos-${{ matrix.target }}
+          path: dist
+
+  sdist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build sdist
+        uses: PyO3/maturin-action@v1
+        with:
+          command: sdist
+          args: --out dist -m ${{ env.MANIFEST }}
+      - name: Upload sdist
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-sdist
+          path: dist
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: [linux, windows, macos, sdist]
+    # Trusted Publishing (OIDC): configure a PyPI publisher for this repo + workflow. Swap for
+    # `MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}` if you publish with a token instead.
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+      - name: Publish to PyPI
+        uses: PyO3/maturin-action@v1
+        with:
+          command: upload
+          args: --non-interactive --skip-existing wheels-*/*

--- a/.github/workflows/release-pymzdata.yml
+++ b/.github/workflows/release-pymzdata.yml
@@ -2,8 +2,8 @@ name: Release pymzdata
 
 # Build the crates/pymzdata wheels + sdist and publish them to PyPI, so downstreams users can
 # `pip install pymzdata` without a Rust toolchain. Mirrors the maturin-action layout used by the
-# ms2rescore-rs, with two crate-specific  additions: the `-m crates/pymzdata/Cargo.toml` manifest
-# (pymzdata is a sub-crate) and a cmake install for the zlib-ng-compat mzdata feature.
+# ms2rescore-rs, with one crate-specific addition: the `-m crates/pymzdata/Cargo.toml` manifest
+# (pymzdata is a sub-crate). mzdata uses the pure-Rust zlib-rs backend, so no C toolchain is needed.
 on:
   release:
     types: [created]
@@ -33,8 +33,6 @@ jobs:
           args: --release --out dist --find-interpreter -m ${{ env.MANIFEST }}
           sccache: "true"
           manylinux: auto
-          # pymzdata pulls the zlib-ng-compat mzdata feature; its libz-ng-sys build needs cmake.
-          before-script-linux: command -v cmake >/dev/null || (yum install -y cmake || dnf install -y cmake || (apt-get update && apt-get install -y cmake))
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,6 +54,30 @@ jobs:
           command: test
           args: --features async,proxi,proxi-async -- --nocapture --show-output
 
+  test-pymzdata:
+    name: pymzdata Python Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Build pymzdata wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          args: --release --out dist -m crates/pymzdata/Cargo.toml
+          manylinux: off
+          rust-toolchain: stable
+      - name: Install pymzdata and test dependencies
+        run: |
+          python -m pip install dist/*.whl
+          python -m pip install 'pytest>=7' 'numpy>=1.21' 'pyteomics>=4.6' 'lxml>=4.9' 'psims>=1.3'
+      - name: Run Python tests
+        working-directory: crates/pymzdata
+        run: python -m pytest
+
   test-spectra-subset:
     name: mzdata-spectra
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -76,7 +76,7 @@ jobs:
           python -m pip install 'pytest>=7' 'numpy>=1.21' 'pyteomics>=4.6' 'lxml>=4.9' 'psims>=1.3'
       - name: Run Python tests
         working-directory: crates/pymzdata
-        run: python -m pytest
+        run: python -m pytest crates/pymzdata/
 
   test-spectra-subset:
     name: mzdata-spectra

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -76,7 +76,7 @@ jobs:
           python -m pip install 'pytest>=7' 'numpy>=1.21' 'pyteomics>=4.6' 'lxml>=4.9' 'psims>=1.3'
       - name: Run Python tests
         working-directory: crates/pymzdata
-        run: python -m pytest crates/pymzdata/
+        run: python -m pytest -v -s
 
   test-spectra-subset:
     name: mzdata-spectra

--- a/Justfile
+++ b/Justfile
@@ -30,6 +30,10 @@ update-cv:
 update-cv-terms:
     cog -c -r -U src/meta/software.rs src/meta/instrument.rs src/meta/file_description.rs src/io/mzml/writer.rs src/meta/activation.rs
 
+pytest:
+    maturin develop -m "./crates/pymzdata/Cargo.toml"
+    pytest -v -s ./crates/pymzdata/
+
 changelog version:
     #!/usr/bin/env python
 

--- a/crates/pymzdata/.gitignore
+++ b/crates/pymzdata/.gitignore
@@ -70,3 +70,7 @@ docs/_build/
 
 # Pyenv
 .python-version
+
+# Track the Python test suite (the repo-wide *.py ignore would otherwise hide it).
+!tests/
+!tests/*.py

--- a/crates/pymzdata/Cargo.lock
+++ b/crates/pymzdata/Cargo.lock
@@ -108,12 +108,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base16ct"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -585,9 +579,9 @@ dependencies = [
 
 [[package]]
 name = "dotnetrawfilereader-sys"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93e8a6b7baa7128720283bf0667d10297e3d5d78e537ff7cfa07b56a4e89ff2e"
+checksum = "54656bb5cfcee01b9e2b8b3d624252f8275c415e3ac8ff965166e7b4a2da07f0"
 dependencies = [
  "include_dir",
  "netcorehost",
@@ -705,7 +699,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
- "libz-sys",
  "miniz_oxide",
  "zlib-rs",
 ]
@@ -1350,19 +1343,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libz-sys"
-version = "1.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4735e9cbde5aac84a5ce588f6b23a90b9b0b528f6c5a8db8a4aff300463a0839"
-dependencies = [
- "cc",
- "cmake",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "linreg"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1432,12 +1412,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "md5"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
-
-[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1481,9 +1455,8 @@ dependencies = [
 
 [[package]]
 name = "mzdata"
-version = "0.65.3"
+version = "0.65.4"
 dependencies = [
- "base16ct",
  "base64-simd",
  "bitflags",
  "bytemuck",
@@ -1493,7 +1466,6 @@ dependencies = [
  "identity-hash",
  "indexmap 2.13.0",
  "log",
- "md5",
  "memchr",
  "mzpeaks",
  "mzsignal",
@@ -1856,7 +1828,7 @@ dependencies = [
 
 [[package]]
 name = "pymzdata"
-version = "0.65.2"
+version = "0.65.4"
 dependencies = [
  "mzdata",
  "mzpeaks",
@@ -1926,9 +1898,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.30.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
  "serde",
@@ -2666,9 +2638,9 @@ dependencies = [
 
 [[package]]
 name = "thermorawfilereader"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "515cbeb0de35e3f4dd2b9ab682f37bd613cfde6e38f60d1156986554c695a69c"
+checksum = "2274064550a7cc2d9081e191e2f91bee5058f9e0e9bb7cb272ad6c714dad1522"
 dependencies = [
  "bytemuck",
  "dotnetrawfilereader-sys",

--- a/crates/pymzdata/Cargo.toml
+++ b/crates/pymzdata/Cargo.toml
@@ -20,7 +20,7 @@ imzml = []
 
 [dependencies]
 pyo3 = { version = "0.28.0", features = ["extension-module", "abi3-py39", "serde"] }
-mzdata = { path = "../../", version = "0.65.4", default-features = false, features = ["mzml", "mgf", "nalgebra", "bruker_tdf", "thermo", "zlib-ng-compat", "proxi", "imzml"] }
+mzdata = { path = "../../", version = "0.65.4", default-features = false, features = ["mzml", "mgf", "nalgebra", "bruker_tdf", "thermo", "zlib-rs", "proxi", "imzml"] }
 mzpeaks = { version = ">=1.0.6,<1.1.0" }
 numpy = "0.28.0"
 serde-pyobject = "0.8.0"

--- a/crates/pymzdata/pyproject.toml
+++ b/crates/pymzdata/pyproject.toml
@@ -4,7 +4,9 @@ build-backend = "maturin"
 
 [project]
 name = "pymzdata"
-requires-python = ">=3.8"
+# The binding is built abi3-py39, so 3.9 is the real minimum.
+requires-python = ">=3.9"
+license = "Apache-2.0"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",

--- a/crates/pymzdata/pyproject.toml
+++ b/crates/pymzdata/pyproject.toml
@@ -13,3 +13,13 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dynamic = ["version"]
+
+[project.optional-dependencies]
+# `pip install pymzdata[test]` to run the Python test suite. numpy is needed to use the returned peak
+# arrays; pyteomics (+ its lxml / psims deps) powers the parity cross-check that validates pymzdata's
+# output against an independent mzML reader.
+test = ["pytest>=7", "numpy>=1.21", "pyteomics>=4.6", "lxml>=4.9", "psims>=1.3"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-ra"

--- a/crates/pymzdata/src/reader.rs
+++ b/crates/pymzdata/src/reader.rs
@@ -219,7 +219,12 @@ impl PyMZReader {
 
     /// Convert this reader to an IMMZReader for ion mobility frame access.
     ///
-    /// Raises ``RuntimeError`` if the file does not contain ion mobility data.
+    /// This *consumes* the reader: the underlying file reader is moved into the returned
+    /// ``IMMZReader``, leaving this ``MZReader`` closed (``closed()`` becomes ``True`` and any
+    /// further use raises ``RuntimeError``).
+    ///
+    /// Raises ``RuntimeError`` if the reader is already closed, or if the file does not contain ion
+    /// mobility data.
     fn into_frame_reader(&mut self) -> PyResult<PyIMMZReader> {
         let inner = self.inner.take().ok_or_else(|| {
             PyRuntimeError::new_err("Reader is already closed")

--- a/crates/pymzdata/tests/conftest.py
+++ b/crates/pymzdata/tests/conftest.py
@@ -1,0 +1,68 @@
+"""Shared fixtures for the pymzdata Python test suite.
+
+The suite reads the small sample files under the repository's ``test/data`` directory and asserts on
+invariants of the parsed output (types, array shapes, sort order, m/z-in-isolation-window, etc.) rather
+than hard-coded numbers, so it is robust to the exact sample files. A cross-check against ``pyteomics``
+(a ``[test]`` dependency) validates the numeric values against an independent reader.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+import pymzdata
+
+# This file: <repo-root>/crates/pymzdata/tests/conftest.py -> repo root is three levels up.
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+_DATA_DIR = _REPO_ROOT / "test" / "data"
+
+
+@pytest.fixture(scope="session")
+def data_dir() -> pathlib.Path:
+    """The repository's sample-data directory."""
+    if not _DATA_DIR.is_dir():
+        pytest.skip(f"sample data directory not found: {_DATA_DIR}")
+    return _DATA_DIR
+
+
+@pytest.fixture(scope="session")
+def mzml_path(data_dir: pathlib.Path) -> str:
+    """Path to the small mzML sample."""
+    path = data_dir / "small.mzML"
+    if not path.exists():
+        pytest.skip("small.mzML not available")
+    return str(path)
+
+
+@pytest.fixture
+def reader(mzml_path: str):
+    """An open MZReader over the small mzML sample (closed on teardown)."""
+    with pymzdata.MZReader(mzml_path) as r:
+        yield r
+
+
+@pytest.fixture(scope="session")
+def spectra(mzml_path: str) -> list:
+    """Every spectrum in the small mzML sample, materialised once."""
+    with pymzdata.MZReader(mzml_path) as r:
+        return list(r)
+
+
+@pytest.fixture(scope="session")
+def ms1_spectrum(spectra: list):
+    """The first MS1 spectrum."""
+    for spectrum in spectra:
+        if spectrum.ms_level == 1:
+            return spectrum
+    pytest.skip("no MS1 spectrum in the sample file")
+
+
+@pytest.fixture(scope="session")
+def ms2_spectrum(spectra: list):
+    """The first MS2 spectrum that carries a precursor."""
+    for spectrum in spectra:
+        if spectrum.ms_level == 2 and spectrum.precursor is not None:
+            return spectrum
+    pytest.skip("no MS2 spectrum with a precursor in the sample file")

--- a/crates/pymzdata/tests/test_ion_mobility.py
+++ b/crates/pymzdata/tests/test_ion_mobility.py
@@ -1,0 +1,48 @@
+"""Ion-mobility frame reading via IMMZReader (skipped where the sample lacks IM data)."""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+import pymzdata
+
+
+def _open_im_reader(path: pathlib.Path):
+    try:
+        return pymzdata.IMMZReader(str(path))
+    except (RuntimeError, IOError, OSError) as exc:
+        pytest.skip(f"ion-mobility frames not available for {path.name}: {exc}")
+
+
+def test_immzreader_frames(data_dir: pathlib.Path) -> None:
+    path = data_dir / "diaPASEF.mzML"
+    if not path.exists():
+        pytest.skip("diaPASEF.mzML not available")
+    with _open_im_reader(path) as reader:
+        n = len(reader)
+        if n == 0:
+            pytest.skip("no ion-mobility frames in the sample")
+        frame = reader.get_by_index(0)
+        assert frame is not None
+        assert isinstance(frame.id, str) and frame.id
+        assert frame.ms_level >= 1
+        assert isinstance(frame.start_time, float)
+        raw = frame.raw_arrays()
+        assert isinstance(raw, dict)
+
+
+def test_into_frame_reader_from_mzreader(data_dir: pathlib.Path) -> None:
+    path = data_dir / "diaPASEF.mzML"
+    if not path.exists():
+        pytest.skip("diaPASEF.mzML not available")
+    reader = pymzdata.MZReader(str(path))
+    try:
+        frame_reader = reader.into_frame_reader()
+    except (RuntimeError, IOError, OSError) as exc:
+        pytest.skip(f"cannot convert to frame reader: {exc}")
+    with frame_reader as fr:
+        assert len(fr) >= 0
+    # into_frame_reader() consumes the MZReader (moves the underlying reader out), leaving it closed.
+    assert reader.closed()

--- a/crates/pymzdata/tests/test_metadata.py
+++ b/crates/pymzdata/tests/test_metadata.py
@@ -1,0 +1,52 @@
+"""File-level metadata: file description, instrument configs, software, samples, processing."""
+
+from __future__ import annotations
+
+
+def test_file_description(reader) -> None:
+    description = reader.file_description()
+    assert isinstance(description.source_files(), list)
+    assert isinstance(description.has_msn_spectra, bool)
+    for source in description.source_files():
+        assert isinstance(source.name, str)
+        assert isinstance(source.location, str)
+
+
+def test_instrument_configurations(reader) -> None:
+    configs = reader.instrument_configurations()
+    assert isinstance(configs, list)
+    for config in configs:
+        assert isinstance(config.id, int)
+        for component in config.components():
+            assert component.order >= 0
+            for accessor in (component.mass_analyzer, component.detector, component.ionization_type):
+                assert accessor is None or isinstance(accessor, str)
+
+
+def test_softwares(reader) -> None:
+    softwares = reader.softwares()
+    assert isinstance(softwares, list)
+    for software in softwares:
+        assert isinstance(software.id, str)
+        assert isinstance(software.version, str)
+
+
+def test_samples(reader) -> None:
+    for sample in reader.samples():
+        assert isinstance(sample.id, str)
+        assert sample.name is None or isinstance(sample.name, str)
+
+
+def test_run_description(reader) -> None:
+    run = reader.run_description()
+    if run is not None:
+        assert run.id is None or isinstance(run.id, str)
+        assert run.default_instrument_id is None or isinstance(run.default_instrument_id, int)
+
+
+def test_data_processings(reader) -> None:
+    for processing in reader.data_processings():
+        assert isinstance(processing.id, str)
+        for method in processing.methods():
+            assert isinstance(method.order, int)
+            assert isinstance(method.software_reference, str)

--- a/crates/pymzdata/tests/test_mgf.py
+++ b/crates/pymzdata/tests/test_mgf.py
@@ -1,0 +1,42 @@
+"""Reading MGF files through the same MZReader interface."""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+import pymzdata
+
+
+@pytest.fixture(scope="module")
+def mgf_spectra(data_dir: pathlib.Path) -> list:
+    path = data_dir / "small.mgf"
+    if not path.exists():
+        pytest.skip("small.mgf not available")
+    with pymzdata.MZReader(str(path)) as reader:
+        return list(reader)
+
+
+def test_mgf_reads_spectra(mgf_spectra: list) -> None:
+    assert len(mgf_spectra) > 0
+
+
+def test_mgf_spectra_are_msn_with_peaks(mgf_spectra: list) -> None:
+    for spectrum in mgf_spectra[:25]:
+        # MGF holds fragmentation spectra: MS level > 1, a precursor, and a non-empty peak list.
+        assert spectrum.ms_level >= 2
+        assert spectrum.precursor is not None
+        # MGF peaks are decoded into the centroid peak list (not the raw binary arrays), so
+        # mz_array() is None here; the peaks come through centroid_peaks().
+        peaks = spectrum.centroid_peaks()
+        assert peaks is not None
+        mz, intensity = peaks
+        assert len(mz) == len(intensity) > 0
+        assert len(spectrum) == len(mz)
+
+
+def test_mgf_precursor(mgf_spectra: list) -> None:
+    ions = mgf_spectra[0].precursor.ions()
+    assert len(ions) >= 1
+    assert ions[0].mz > 0

--- a/crates/pymzdata/tests/test_params.py
+++ b/crates/pymzdata/tests/test_params.py
@@ -1,0 +1,47 @@
+"""Controlled-vocabulary Param access and lookup."""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_param_fields(ms1_spectrum) -> None:
+    for param in ms1_spectrum.params():
+        assert isinstance(param.name, str)
+        assert param.id is None or isinstance(param.id, str)
+        assert isinstance(param.unit, str)
+        assert param.value is None or isinstance(param.value, (str, float, int, bool, list))
+
+
+def test_find_param_requires_an_argument(ms1_spectrum) -> None:
+    with pytest.raises(TypeError):
+        ms1_spectrum.find_param()
+
+
+def test_find_param_by_name(ms1_spectrum) -> None:
+    params = ms1_spectrum.params()
+    if not params:
+        pytest.skip("spectrum exposes no params")
+    name = params[0].name
+    found = ms1_spectrum.find_param(name=name)
+    assert found is not None
+    assert found.name == name
+
+
+def test_find_param_by_accession(ms1_spectrum) -> None:
+    with_accession = [p for p in ms1_spectrum.params() if p.id]
+    if not with_accession:
+        pytest.skip("no param with an accession")
+    accession = with_accession[0].id
+    found = ms1_spectrum.find_param(accession=accession)
+    assert found is not None
+    assert found.id == accession
+
+
+def test_find_param_missing_name_returns_none(ms1_spectrum) -> None:
+    assert ms1_spectrum.find_param(name="this parameter does not exist") is None
+
+
+def test_find_param_invalid_accession_raises(ms1_spectrum) -> None:
+    with pytest.raises(ValueError):
+        ms1_spectrum.find_param(accession="not-a-valid-curie")

--- a/crates/pymzdata/tests/test_precursor.py
+++ b/crates/pymzdata/tests/test_precursor.py
@@ -1,0 +1,43 @@
+"""Precursor, isolation window, selected ions, and activation for MS2 spectra."""
+
+from __future__ import annotations
+
+
+def test_ms2_has_precursor(ms2_spectrum) -> None:
+    assert ms2_spectrum.precursor is not None
+
+
+def test_isolation_window(ms2_spectrum) -> None:
+    window = ms2_spectrum.precursor.isolation_window
+    assert window.lower_bound <= window.target <= window.upper_bound
+    assert window.contains(window.target)
+
+
+def test_selected_ions(ms2_spectrum) -> None:
+    ions = ms2_spectrum.precursor.ions()
+    assert len(ions) >= 1
+    ion = ions[0]
+    assert ion.mz > 0
+    assert ion.intensity >= 0
+    assert ion.charge is None or (isinstance(ion.charge, int) and ion.charge != 0)
+
+
+def test_selected_ion_near_isolation_window(ms2_spectrum) -> None:
+    precursor = ms2_spectrum.precursor
+    ion = precursor.ions()[0]
+    window = precursor.isolation_window
+    # The selected ion should lie within the isolation window (allow a small margin for windows
+    # recorded only as a target width).
+    assert window.contains(float(ion.mz)) or (window.lower_bound - 5.0 <= ion.mz <= window.upper_bound + 5.0)
+
+
+def test_activation(ms2_spectrum) -> None:
+    activation = ms2_spectrum.precursor.activation
+    assert activation.energy >= 0
+    assert activation.method is None or isinstance(activation.method, str)
+    assert isinstance(activation.methods(), list)
+
+
+def test_precursor_id_type(ms2_spectrum) -> None:
+    precursor_id = ms2_spectrum.precursor.precursor_id
+    assert precursor_id is None or isinstance(precursor_id, str)

--- a/crates/pymzdata/tests/test_pyteomics_parity.py
+++ b/crates/pymzdata/tests/test_pyteomics_parity.py
@@ -1,0 +1,92 @@
+"""Cross-check: pymzdata and pyteomics must parse the same mzML identically.
+
+pyteomics is part of the ``[test]`` extra, so this runs as a normal part of the suite. It validates
+pymzdata's decoded output against an independent, widely-used reader: peak arrays, MS level, retention
+time (unit-normalised to minutes), and the precursor selected ion. The ``importorskip`` below is a
+defensive fallback so the rest of the suite still runs on a platform where pyteomics (or its lxml /
+psims dependencies) fails to install.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import pymzdata
+
+pyteomics_mzml = pytest.importorskip("pyteomics.mzml", reason="pyteomics not installed")
+
+
+def _rt_minutes(scan_start_time) -> float:
+    """Normalise a pyteomics 'scan start time' to minutes (pymzdata reports minutes)."""
+    unit = getattr(scan_start_time, "unit_info", None)
+    value = float(scan_start_time)
+    return value / 60.0 if unit == "second" else value
+
+
+@pytest.fixture(scope="module")
+def pyteomics_by_id(mzml_path: str) -> dict:
+    """All pyteomics spectra keyed by native id."""
+    out = {}
+    with pyteomics_mzml.MzML(mzml_path) as handle:
+        for spec in handle:
+            out[spec["id"]] = spec
+    return out
+
+
+def test_same_spectrum_count(pyteomics_by_id: dict, spectra: list) -> None:
+    assert len(spectra) == len(pyteomics_by_id)
+
+
+def test_ms_level_and_peaks_match(pyteomics_by_id: dict, spectra: list) -> None:
+    compared = 0
+    for spectrum in spectra:
+        reference = pyteomics_by_id.get(spectrum.id)
+        assert reference is not None, f"pyteomics has no spectrum with id {spectrum.id!r}"
+
+        assert spectrum.ms_level == int(reference["ms level"])
+
+        mz = spectrum.mz_array()
+        if mz is None or "m/z array" not in reference:
+            continue
+        ref_mz = np.asarray(reference["m/z array"], dtype=np.float64)
+        ref_intensity = np.asarray(reference["intensity array"], dtype=np.float64)
+        intensity = spectrum.intensity_array()
+
+        assert len(mz) == len(ref_mz), f"m/z length mismatch for {spectrum.id!r}"
+        np.testing.assert_allclose(mz, ref_mz, rtol=1e-6, atol=1e-4)
+        # intensities round-trip through f32 in pymzdata, so allow f32-scale tolerance.
+        np.testing.assert_allclose(intensity, ref_intensity, rtol=1e-3, atol=1e-2)
+        compared += 1
+    assert compared > 0, "no spectra with peak arrays were compared"
+
+
+def test_retention_time_matches(pyteomics_by_id: dict, spectra: list) -> None:
+    for spectrum in spectra:
+        reference = pyteomics_by_id[spectrum.id]
+        scans = reference.get("scanList", {}).get("scan", [])
+        if not scans or "scan start time" not in scans[0]:
+            continue
+        assert spectrum.start_time == pytest.approx(_rt_minutes(scans[0]["scan start time"]), abs=1e-3)
+
+
+def test_precursor_selected_ion_matches(pyteomics_by_id: dict, spectra: list) -> None:
+    compared = 0
+    for spectrum in spectra:
+        if spectrum.ms_level < 2 or spectrum.precursor is None:
+            continue
+        reference = pyteomics_by_id[spectrum.id]
+        precursors = reference.get("precursorList", {}).get("precursor", [])
+        if not precursors:
+            continue
+        ref_ions = precursors[0].get("selectedIonList", {}).get("selectedIon", [])
+        if not ref_ions:
+            continue
+        ref_mz = float(ref_ions[0]["selected ion m/z"])
+        ion = spectrum.precursor.ions()[0]
+        assert ion.mz == pytest.approx(ref_mz, rel=1e-6, abs=1e-4)
+        if "charge state" in ref_ions[0] and ion.charge is not None:
+            assert ion.charge == int(ref_ions[0]["charge state"])
+        compared += 1
+    if compared == 0:
+        pytest.skip("no MS2 precursors to compare")

--- a/crates/pymzdata/tests/test_reader.py
+++ b/crates/pymzdata/tests/test_reader.py
@@ -1,0 +1,90 @@
+"""Reader lifecycle, iteration, random access, detail level, and error handling."""
+
+from __future__ import annotations
+
+import pytest
+
+import pymzdata
+
+
+def test_open_and_close(mzml_path: str) -> None:
+    r = pymzdata.MZReader(mzml_path)
+    assert not r.closed()
+    assert len(r) > 0
+    r.close()
+    assert r.closed()
+
+
+def test_context_manager_closes(mzml_path: str) -> None:
+    with pymzdata.MZReader(mzml_path) as r:
+        assert not r.closed()
+        n = len(r)
+    assert r.closed()
+    assert n > 0
+
+
+def test_iteration_count_matches_len(mzml_path: str) -> None:
+    with pymzdata.MZReader(mzml_path) as r:
+        expected = len(r)
+        count = sum(1 for _ in r)
+    assert count == expected
+
+
+def test_repr(reader) -> None:
+    assert "MZReader" in repr(reader)
+    assert "open" in repr(reader)
+
+
+def test_get_by_index(mzml_path: str) -> None:
+    with pymzdata.MZReader(mzml_path) as r:
+        first = r.get_by_index(0)
+        assert first is not None
+        assert first.index == 0
+        # Out-of-range index returns None rather than raising.
+        assert r.get_by_index(10**9) is None
+
+
+def test_get_by_id_roundtrip(mzml_path: str) -> None:
+    with pymzdata.MZReader(mzml_path) as r:
+        first = r.get_by_index(0)
+        again = r.get_by_id(first.id)
+        assert again is not None
+        assert again.id == first.id
+        assert again.index == first.index
+
+
+def test_get_by_id_missing(mzml_path: str) -> None:
+    with pymzdata.MZReader(mzml_path) as r:
+        assert r.get_by_id("controllerType=0 controllerNumber=1 scan=999999999") is None
+
+
+def test_get_by_time(mzml_path: str, spectra: list) -> None:
+    target = spectra[len(spectra) // 2].start_time
+    with pymzdata.MZReader(mzml_path) as r:
+        found = r.get_by_time(target)
+    assert found is not None
+    # The returned spectrum's time is at least as close as the extremes of the run.
+    span = max(abs(spectra[0].start_time - target), abs(spectra[-1].start_time - target))
+    assert abs(found.start_time - target) <= span + 1e-6
+
+
+def test_file_not_found() -> None:
+    with pytest.raises((IOError, OSError)):
+        pymzdata.MZReader("/no/such/file/definitely_missing.mzML")
+
+
+def test_operations_on_closed_reader(mzml_path: str) -> None:
+    r = pymzdata.MZReader(mzml_path)
+    r.close()
+    with pytest.raises(RuntimeError):
+        r.get_by_index(0)
+    with pytest.raises(RuntimeError):
+        r.file_description()
+
+
+def test_detail_level_getter_and_roundtrip(reader) -> None:
+    level = reader.detail_level
+    assert "DetailLevel" in repr(level)
+    # Round-tripping the current level must not raise.
+    reader.detail_level = level
+    assert "DetailLevel" in repr(reader.detail_level)

--- a/crates/pymzdata/tests/test_spectrum.py
+++ b/crates/pymzdata/tests/test_spectrum.py
@@ -1,0 +1,95 @@
+"""Spectrum fields, peak arrays, params, and scan events."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import pymzdata
+
+
+def test_basic_fields(spectra: list) -> None:
+    for spectrum in spectra:
+        assert isinstance(spectrum.id, str) and spectrum.id
+        assert isinstance(spectrum.index, int) and spectrum.index >= 0
+        assert isinstance(spectrum.ms_level, int) and spectrum.ms_level >= 1
+        assert isinstance(spectrum.start_time, float)
+
+
+def test_index_matches_iteration_order(spectra: list) -> None:
+    for i, spectrum in enumerate(spectra):
+        assert spectrum.index == i
+
+
+def test_signal_continuity_flags(spectra: list) -> None:
+    profile = pymzdata.SignalContinuity.Profile
+    centroid = pymzdata.SignalContinuity.Centroid
+    for spectrum in spectra:
+        sc = spectrum.signal_continuity
+        assert sc in (pymzdata.SignalContinuity.Unknown, centroid, profile)
+        assert spectrum.is_profile == (sc == profile)
+        assert spectrum.is_centroid == (sc == centroid)
+
+
+def test_mz_and_intensity_arrays(spectra: list) -> None:
+    saw_arrays = False
+    for spectrum in spectra:
+        mz = spectrum.mz_array()
+        intensity = spectrum.intensity_array()
+        if mz is None:
+            continue
+        saw_arrays = True
+        assert isinstance(mz, np.ndarray) and mz.dtype == np.float64
+        assert isinstance(intensity, np.ndarray) and intensity.dtype == np.float32
+        assert mz.shape == intensity.shape
+        assert len(mz) == len(spectrum)
+        assert np.all(np.diff(mz) >= 0), "m/z array must be sorted ascending"
+        assert np.all(intensity >= 0), "intensities must be non-negative"
+    assert saw_arrays, "no spectrum exposed an m/z array"
+
+
+def test_len_matches_peak_count(spectra: list) -> None:
+    for spectrum in spectra:
+        mz = spectrum.mz_array()
+        assert len(spectrum) == (0 if mz is None else len(mz))
+
+
+def test_raw_arrays_contains_mz(ms1_spectrum) -> None:
+    raw = ms1_spectrum.raw_arrays()
+    assert isinstance(raw, dict)
+    joined = " ".join(raw.keys()).lower()
+    assert "m/z" in joined or "mz" in joined
+    for value in raw.values():
+        assert isinstance(value, np.ndarray)
+
+
+def test_centroid_peaks_shape(spectra: list) -> None:
+    for spectrum in spectra:
+        peaks = spectrum.centroid_peaks()
+        if peaks is None:
+            continue
+        mz, intensity = peaks
+        assert isinstance(mz, np.ndarray) and isinstance(intensity, np.ndarray)
+        assert mz.shape == intensity.shape
+
+
+def test_scan_events(ms1_spectrum) -> None:
+    events = ms1_spectrum.scan_events()
+    assert isinstance(events, list)
+    for event in events:
+        assert isinstance(event.start_time, float)
+        assert event.injection_time >= 0
+        filter_string = event.filter_string()
+        assert filter_string is None or isinstance(filter_string, str)
+        for window in event.scan_windows():
+            assert window.lower_bound <= window.upper_bound
+            assert window.contains((window.lower_bound + window.upper_bound) / 2)
+
+
+def test_repr(ms1_spectrum) -> None:
+    assert "Spectrum(" in repr(ms1_spectrum)
+
+
+def test_to_proxi(ms1_spectrum) -> None:
+    proxi = ms1_spectrum.to_proxi()
+    assert isinstance(proxi, dict)

--- a/src/spectrum/scan_properties.rs
+++ b/src/spectrum/scan_properties.rs
@@ -84,7 +84,7 @@ impl IsolationWindow {
 
     pub fn contains<F: Float>(&self, point: F) -> bool {
         let point = point.to_f32().unwrap();
-        self.lower_bound <= point && self.upper_bound <= point
+        self.lower_bound <= point && point <= self.upper_bound
     }
 
     pub fn is_empty(&self) -> bool {
@@ -120,7 +120,7 @@ impl ScanWindow {
 
     pub fn contains<F: Float>(&self, point: F) -> bool {
         let point = point.to_f32().unwrap();
-        self.lower_bound <= point && self.upper_bound <= point
+        self.lower_bound <= point && point <= self.upper_bound
     }
 
     pub fn is_empty(&self) -> bool {
@@ -971,3 +971,33 @@ impl ChromatogramDescription {
 }
 
 impl_param_described!(ChromatogramDescription);
+
+#[cfg(test)]
+mod contains_tests {
+    use super::*;
+
+    // Regression tests for the isolation/scan-window `contains` membership check. A prior bug used
+    // `lower <= point && upper <= point`, which wrongly excluded interior points and wrongly included
+    // points above the window; `contains` must be an inclusive `[lower, upper]` test.
+
+    #[test]
+    fn isolation_window_contains_is_inclusive_range() {
+        let window = IsolationWindow::around(810.789, 1.0); // [809.789, 811.789]
+        assert!(window.contains(window.target), "target must be inside");
+        assert!(window.contains(window.lower_bound), "lower bound is inclusive");
+        assert!(window.contains(window.upper_bound), "upper bound is inclusive");
+        assert!(window.contains(810.0_f64), "interior point");
+        assert!(!window.contains(809.0_f64), "below the lower bound");
+        assert!(!window.contains(812.0_f64), "above the upper bound");
+    }
+
+    #[test]
+    fn scan_window_contains_is_inclusive_range() {
+        let window = ScanWindow::new(200.0, 2000.0);
+        assert!(window.contains(1100.0_f64), "interior point");
+        assert!(window.contains(200.0_f64), "lower bound is inclusive");
+        assert!(window.contains(2000.0_f64), "upper bound is inclusive");
+        assert!(!window.contains(199.0_f64), "below the lower bound");
+        assert!(!window.contains(2500.0_f64), "above the upper bound (the old bug returned true here)");
+    }
+}


### PR DESCRIPTION
Add a maturin-action workflow that builds wheels (Linux/macOS/Windows, x86_64 + aarch64/x86) and an sdist for `crates/pymzdata` and publishes them to PyPI on a GitHub release via trusted publishing. Lets downstreams `pip install pymzdata` without a Rust toolchain. 

Closes #55