### PR TITLE
docs: describe pymzdata bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,22 @@
 
 A Rust library for reading mass spectrometry data file formats.
 
+## Python bindings
+
+Python bindings are available as [pymzdata](https://pypi.org/project/pymzdata/).
+Install them with:
+
+```console
+pip install pymzdata
+```
+
+`pymzdata` provides Python 3.9+ access to mass spectrometry files through
+`MZReader`, including iteration, random spectrum access, metadata, and NumPy peak
+arrays. It supports mzML and indexed mzML, MGF, Bruker TDF, and imzML files.
+Thermo RAW files also require their native runtime dependencies. See the
+[pymzdata README](crates/pymzdata/README.md) for an example and ion-mobility frame
+access.
+
 ## Quickstart
 ```rust
 use std::fs;

--- a/crates/pymzdata/README.md
+++ b/crates/pymzdata/README.md
@@ -1,0 +1,53 @@
+# pymzdata
+
+`pymzdata` provides Python bindings for [mzdata](https://github.com/mobiusklein/mzdata),
+a fast Rust library for reading mass spectrometry data files.
+
+## Supported formats
+
+`MZReader` supports mzML and indexed mzML, MGF, Bruker TDF, and imzML files.
+`IMMZReader` provides ion-mobility frame access for compatible mzML and Bruker TDF
+files. Thermo RAW is also supported when its native runtime dependencies are
+available on the host system.
+
+## Installation
+
+```console
+pip install pymzdata
+```
+
+Python 3.9 or later is required. NumPy is installed automatically and is used for
+the peak arrays returned by the reader.
+
+## Quickstart
+
+```python
+import pymzdata
+
+with pymzdata.MZReader("example.mzML") as reader:
+    print(f"{len(reader)} spectra")
+
+    for spectrum in reader:
+        print(spectrum.id, spectrum.ms_level, spectrum.start_time)
+        mz = spectrum.mz_array()
+        intensity = spectrum.intensity_array()
+        if mz is not None:
+            print(f"  {len(mz)} peaks")
+```
+
+`MZReader` supports iteration and random access with `get_by_index`, `get_by_id`,
+and `get_by_time` (retention time in minutes). Spectrum metadata, precursor
+information, and decoded NumPy peak arrays are available from each `Spectrum`.
+
+For Bruker ion-mobility data, use `IMMZReader` directly or convert an open
+`MZReader` with `into_frame_reader()` to access ion-mobility frames.
+
+## Development
+
+To build the bindings from a checkout, install [maturin](https://www.maturin.rs/)
+and run:
+
+```console
+cd crates/pymzdata
+maturin develop
+```

--- a/crates/pymzdata/pyproject.toml
+++ b/crates/pymzdata/pyproject.toml
@@ -4,6 +4,8 @@ build-backend = "maturin"
 
 [project]
 name = "pymzdata"
+description = "Python bindings for reading mass spectrometry data with mzdata"
+readme = "README.md"
 # The binding is built abi3-py39, so 3.9 is the real minimum.
 requires-python = ">=3.9"
 license = "Apache-2.0"
@@ -13,6 +15,11 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dynamic = ["version"]
+
+[project.urls]
+Homepage = "https://github.com/mobiusklein/mzdata"
+Repository = "https://github.com/mobiusklein/mzdata"
+Issues = "https://github.com/mobiusklein/mzdata/issues"
 
 [project.optional-dependencies]
 # `pip install pymzdata[test]` to run the Python test suite. numpy is needed to use the returned peak

--- a/crates/pymzdata/src/reader.rs
+++ b/crates/pymzdata/src/reader.rs
@@ -92,8 +92,9 @@ impl PyDetailLevel {
 
 /// A file-based mass spectrometry reader.
 ///
-/// Supports mzML, MGF, Thermo RAW, and Bruker TDF formats. Use as a context
-/// manager (``with`` block) for automatic resource cleanup.
+/// Supports mzML (including indexed mzML), MGF, Bruker TDF, and imzML formats.
+/// Thermo RAW is supported when its native runtime dependencies are available.
+/// Use as a context manager (``with`` block) for automatic resource cleanup.
 ///
 /// Example::
 ///


### PR DESCRIPTION
Thanks for [publising `pymzdata` to PyPI](https://pypi.org/project/pymzdata/)!

This PR adds a `README.md` to `crates/pymzdata` so that there is a project description on PyPI and mentions the existence of the Python bindings in the main `README.md`.